### PR TITLE
Add blue sidebar indicator for sessions awaiting input

### DIFF
--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -30,6 +30,7 @@ export async function GET(req: NextRequest) {
       const running = activeMap.get(session.id);
       if (running) {
         session.status = running.status;
+        session.pendingRequestCount = running.pendingRequestCount;
       }
       const mem = knownMap.get(session.id);
       if (mem) {

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -183,7 +183,12 @@ function SortableSessionRow({
         <GripVertical className="h-4 w-4" />
       </button>
       <div className="shrink-0 relative flex items-center justify-center h-4 w-4">
-        {session.status === "running" ? (
+        {(session.pendingRequestCount ?? 0) > 0 ? (
+          <>
+            <div className="absolute h-4 w-4 rounded-full bg-blue-500/20 animate-ping" />
+            <div className="h-2.5 w-2.5 rounded-full bg-blue-500" title="Awaiting your input" />
+          </>
+        ) : session.status === "running" ? (
           <>
             <div className="absolute h-4 w-4 rounded-full bg-yellow-500/20 animate-ping" />
             <div className="h-2.5 w-2.5 rounded-full bg-yellow-500" title="Working" />
@@ -274,6 +279,11 @@ export const Sidebar = forwardRef<SidebarHandle>(function Sidebar(_props, ref) {
         }
 
         setSessions((list) => list.map((s) => (s.id === sessionId ? { ...s, status: status as SessionInfo["status"] } : s)));
+      } else if (msg.type === "session:pending") {
+        const { sessionId, count } = msg;
+        const known = new Set(sessions.map((s) => s.id));
+        if (!known.has(sessionId)) return;
+        setSessions((list) => list.map((s) => (s.id === sessionId ? { ...s, pendingRequestCount: count } : s)));
       } else if (msg.type === "session:info_updated") {
         const { sessionId, info } = msg;
         setSessions((list) => list.map((s) => (s.id === sessionId ? { ...s, name: info.name, model: info.model } : s)));

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -37,6 +37,7 @@ export interface SessionEvents {
   event: [sessionId: string, event: ParsedEvent];
   status: [sessionId: string, status: "idle" | "running"];
   error: [sessionId: string, error: string];
+  pending: [sessionId: string, count: number];
 }
 
 export interface PendingRequest {
@@ -125,6 +126,7 @@ export class SessionManager {
       lastActiveAt: now,
       status: "idle",
       model: defaults.model || undefined,
+      pendingRequestCount: 0,
     };
 
     this.sessions.set(id, {
@@ -174,6 +176,7 @@ export class SessionManager {
           lastActiveAt: now,
           status: "idle",
           model: prefs?.model || defaults.model || undefined,
+          pendingRequestCount: 0,
         },
         process: null,
         stdin: null,
@@ -503,6 +506,7 @@ export class SessionManager {
     if (session && session.info.status === "running" && !session.process) {
       session.info.status = "idle";
       session.pendingRequests.clear();
+      this.notifyPendingChanged(session, id);
     }
   }
 
@@ -517,6 +521,7 @@ export class SessionManager {
 
     this.killProcess(session);
     session.pendingRequests.clear();
+    this.notifyPendingChanged(session, sessionId);
     session.streamingSnapshot = null;
     session.info.status = "idle";
     session.emitter.emit("status", sessionId, "idle");
@@ -558,6 +563,18 @@ export class SessionManager {
 
     session.emitter.on("status", handler);
     return () => session.emitter.off("status", handler);
+  }
+
+  onPending(id: string, listener: (count: number) => void): (() => void) | null {
+    const session = this.sessions.get(id);
+    if (!session) return null;
+
+    const handler = (_sessionId: string, count: number) => {
+      listener(count);
+    };
+
+    session.emitter.on("pending", handler);
+    return () => session.emitter.off("pending", handler);
   }
 
   onError(id: string, listener: (error: string) => void): (() => void) | null {
@@ -613,6 +630,7 @@ export class SessionManager {
     const session = this.sessions.get(sessionId);
     if (session) {
       session.pendingRequests.set(request.requestId, request);
+      this.notifyPendingChanged(session, sessionId);
     }
   }
 
@@ -620,6 +638,7 @@ export class SessionManager {
     const session = this.sessions.get(sessionId);
     if (session) {
       session.pendingRequests.delete(requestId);
+      this.notifyPendingChanged(session, sessionId);
     }
   }
 
@@ -641,6 +660,7 @@ export class SessionManager {
     if (!session?.stdin) return false;
 
     session.pendingRequests.delete(requestId);
+    this.notifyPendingChanged(session, sessionId);
 
     const response = {
       type: "control_response",
@@ -715,6 +735,7 @@ export class SessionManager {
     }
     // Clear orphaned pending requests from the killed process
     session.pendingRequests.clear();
+    this.notifyPendingChanged(session, sessionId);
     this.emitSystem(session, sessionId, "__plan_state::on");
   }
 
@@ -732,6 +753,7 @@ export class SessionManager {
     }
     // Clear orphaned pending requests from the killed process
     session.pendingRequests.clear();
+    this.notifyPendingChanged(session, sessionId);
     this.emitSystem(session, sessionId, "__plan_state::off");
     // Re-sync bypass state with the client so the UI reflects it correctly
     // after the plan-mode process is torn down.
@@ -1127,6 +1149,13 @@ export class SessionManager {
     session.emitter.emit("system", sessionId, text);
   }
 
+  private notifyPendingChanged(session: Session, sessionId: string): void {
+    const count = session.pendingRequests.size;
+    if (session.info.pendingRequestCount === count) return;
+    session.info.pendingRequestCount = count;
+    session.emitter.emit("pending", sessionId, count);
+  }
+
   private applyProcessedResult(session: Session, sessionId: string, result: import("./stream-processor").ProcessedResult): void {
     for (const msg of result.intermediateMessages) {
       session.emitter.emit("event", sessionId, { type: "message_done", message: msg } as ParsedEvent);
@@ -1178,6 +1207,7 @@ export class SessionManager {
           planFilePath: planPath,
           planContent: planPath ? readPlanFile(planPath) : undefined,
         });
+        this.notifyPendingChanged(session, sessionId);
       }
     }
 

--- a/src/server/ws-handler.ts
+++ b/src/server/ws-handler.ts
@@ -89,6 +89,11 @@ export function createWebSocketHandler(server: HTTPServer, sessionManager: Sessi
       });
       if (unsubStatus) cleanups.push(unsubStatus);
 
+      const unsubPending = sessionManager.onPending(sessionId, (count) => {
+        send(ws, { type: "session:pending", sessionId, count });
+      });
+      if (unsubPending) cleanups.push(unsubPending);
+
       const unsubError = sessionManager.onError(sessionId, (error) => {
         send(ws, { type: "session:error", sessionId, error });
       });
@@ -627,6 +632,11 @@ export function createWebSocketHandler(server: HTTPServer, sessionManager: Sessi
               send(ws, { type: "session:status", sessionId: id, status });
             });
             if (unsubStatus) watchCleanups.push(unsubStatus);
+
+            const unsubPending = sessionManager.onPending(id, (count) => {
+              send(ws, { type: "session:pending", sessionId: id, count });
+            });
+            if (unsubPending) watchCleanups.push(unsubPending);
 
             const unsubInfo = sessionManager.onInfoUpdated(id, (info) => {
               send(ws, { type: "session:info_updated", sessionId: id, info });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface SessionInfo {
   lastActiveAt: number;
   status: "idle" | "running";
   model?: string;
+  pendingRequestCount?: number;
 }
 
 export interface SessionGroup {
@@ -254,6 +255,7 @@ export type ServerMessage =
   | { type: "assistant:message_done"; sessionId: string; message: ChatMessage }
   | { type: "assistant:tool_children"; sessionId: string; messageId: string; toolId: string; children: ToolUse[] }
   | { type: "session:status"; sessionId: string; status: "idle" | "running" }
+  | { type: "session:pending"; sessionId: string; count: number }
   | { type: "session:error"; sessionId: string; error: string }
   | {
       type: "permission:request";


### PR DESCRIPTION
## Summary

- Sessions blocked on a permission prompt or `AskUserQuestion` now show a pulsing blue dot in the sidebar instead of orange, distinguishing "waiting for me" from "actively working"
- New `pendingRequestCount` field on `SessionInfo`, kept in sync as permission/question requests are added/removed; broadcast via a new `session:pending` WS event
- `/api/sessions` propagates the count from in-memory sessions so the initial sidebar load is correct without waiting for a WS event
- Sidebar dot priority: pending > running > unread > idle

## Test plan

- [ ] Trigger a permission prompt (e.g. a Bash command requiring approval) and confirm the sidebar dot for that session goes blue with a pulse, then back to orange/grey/green when answered
- [ ] Trigger an `AskUserQuestion` and confirm same behavior
- [ ] Confirm dot clears the moment the user answers (not on session-view, like unread does)
- [ ] Confirm a fresh page load shows blue immediately for any session already awaiting input
- [ ] Confirm typecheck (next + server) and lint pass; existing 912 tests still green