### PR TITLE
docs: cover 0.3.0 features (runtime modes, providers, terminal, tabs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Three things follow:
 2. **Many Claude Code sessions running at once.** Switch between projects without juggling tmux panes. Sessions live on the server, so closing the browser does not kill them. The chat view stitches across `/clear` so long threads keep their full visual history.
 3. **Cron-driven Claude Code.** Schedule a prompt, walk away. Each run produces a transcript that renders the same as a live session.
 
-Inside a session: a diff viewer for code changes (split or inline), a file viewer with syntax highlighting, global search across all sessions (Ctrl+Shift+F), and plan-mode approvals when Claude proposes a plan. The sidebar shows collapsible sections for sessions, reviews, file changes, and file trees, with status beacons so you can tell at a glance which sessions are working, waiting, or idle.
+Inside a session: a tabbed, split-pane layout holding the chat, a diff viewer for code changes (split or inline), a file viewer with syntax highlighting, and an embedded terminal. Plus global search across all sessions (Ctrl+Shift+F), searchable prompt history on the up arrow, and plan-mode approvals when Claude proposes a plan. The sidebar shows collapsible sections for sessions, reviews, file changes, and file trees, with status beacons so you can tell at a glance which sessions are working, waiting, or idle.
+
+Choose your model per session: built-in Haiku, Sonnet, and Opus, or your own Anthropic-compatible providers (proxies and gateways), with a 200K or 1M context selector. Each session can run in Stream mode (headless) or PTY mode, which drives the real Claude Code CLI through a pseudo-terminal.
 
 It also takes care of things you usually hand-edit: agents, skills, hooks, MCP servers, CLAUDE.md memory. All editable from the UI.
 
@@ -80,6 +82,11 @@ Tested on Linux and macOS. Windows is unverified.
 | `PORT` | Port the server listens on | `3001` |
 | `HOST` | Bind address | `0.0.0.0` |
 | `COCKPIT_RESET_PASSWORD` | Set to `true` to reset password on next startup | `false` |
+| `COCKPIT_CONFIG_DIR` | Cockpit config location (password, providers, defaults, jobs, inbox) | `~/.cockpit` |
+| `CLAUDE_CONFIG_DIR` | Claude config and transcripts Cockpit reads | `~/.claude` |
+| `COCKPIT_DEBUG` | Set to `1` to write a structured debug log | unset |
+
+Setting `COCKPIT_CONFIG_DIR` and `CLAUDE_CONFIG_DIR` together lets you run isolated instances side by side. See [Settings](docs/settings.md#environment-variables) for the full list.
 
 ## Remote access
 
@@ -91,10 +98,12 @@ To restrict Cockpit to the host machine only, set `HOST=127.0.0.1`.
 
 ## Documentation
 
-- [Sessions](docs/sessions.md): chat, sidebar, attachments, plan mode, diffs, file view, todos, search, session linking
+- [Sessions](docs/sessions.md): chat, runtime modes, tabbed layout, sidebar, attachments, plan mode, diffs, file view, prompt history, todos, search, session linking
+- [Model providers](docs/providers.md): built-in and custom Anthropic-compatible providers, context sizes, model slots
+- [Embedded terminal](docs/terminal.md): in-browser shell with themes and mobile support
 - [PR reviews](docs/pr-reviews.md): GitHub PR browsing and review sessions
 - [Scheduled jobs](docs/scheduled-jobs.md): cron-driven Claude Code runs
-- [Settings](docs/settings.md): auth, models, themes, notifications, inbox, agents, skills, hooks, MCP servers, CLAUDE.md
+- [Settings](docs/settings.md): auth, models, providers, themes, notifications, inbox, updates, agents, skills, hooks, MCP servers, CLAUDE.md
 
 ## Development
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,44 @@
+# Model providers
+
+Cockpit can drive Claude Code against more than the built-in Anthropic models. A provider is a named set of environment variables plus a list of models. Selecting a provider model injects that provider's environment into the Claude Code process when the session spawns, so you can point the same UI at a proxy, a gateway, or an Anthropic-compatible endpoint.
+
+The built-in **Anthropic** provider is always present and needs no configuration. It exposes Haiku, Sonnet, and Opus with their version and context-size options.
+
+## Adding a provider
+
+Go to Settings, open the Providers page, and add a provider. The editor has two tabs.
+
+**General**
+
+- **Name.** A label shown in the model picker (for example `OpenRouter` or `Deepseek`).
+- **Environment variables.** Arbitrary `KEY` / `value` pairs that are set on the Claude Code process for sessions using this provider. Values that look like secrets are masked in the form. Common variables:
+  - `ANTHROPIC_BASE_URL` redirects the API to your endpoint.
+  - `ANTHROPIC_AUTH_TOKEN` is sent as a `Bearer` token. Prefer this over `ANTHROPIC_API_KEY`, which makes the CLI prompt for confirmation on first use.
+  - `ANTHROPIC_MODEL` and `ANTHROPIC_DEFAULT_*_MODEL` map Claude's model aliases onto your endpoint's names, if needed.
+
+**Models**
+
+Add each model the provider offers:
+
+- **Model ID.** The identifier passed to the CLI as `--model`.
+- **Display name.** What the picker shows. Defaults to the model ID.
+- **Context sizes.** One or more of 200K and 1M. A model with two sizes shows a size selector in the session settings (see [Sessions](sessions.md#session-settings)).
+- **Effort levels.** Which thinking levels (Low, Medium, High, XHigh, Max) the model supports. The thinking selector only shows levels listed here.
+
+A model must declare at least one context size.
+
+## Selecting a provider model
+
+Provider models appear in the model picker and in the per-session settings popover, grouped by provider. Picking one stores it on the session in the qualified form `provider:modelId`. On the next spawn, Cockpit resolves the provider, passes the bare model ID to `--model`, and applies the provider's environment variables.
+
+Models can be set per slot. The **main** slot drives the conversation. The **subagent** and **fast** slots, when set to a different model, are exported to the CLI so subagents and lightweight calls can use a cheaper or faster model.
+
+## Storage
+
+Custom providers are stored in `~/.cockpit/providers.json`. The built-in Anthropic provider is constructed in code and is not written to disk. Relocate the file with `COCKPIT_CONFIG_DIR` (see [Settings](settings.md#environment-variables)).
+
+## Notes
+
+- Context size drives the CLI's 1M-context switch: choosing 200K sets `CLAUDE_CODE_DISABLE_1M_CONTEXT` for that spawn.
+- A context-size change takes effect on the next CLI start, because the switch is applied at spawn time. Cockpit restarts the process for you when the size changes.
+- The context gauge denominator reflects the size you picked, not what the API reports.

--- a/docs/scheduled-jobs.md
+++ b/docs/scheduled-jobs.md
@@ -19,7 +19,7 @@ The Jobs page lists your jobs. Add one with:
 - Working directory. Where Claude runs (defaults to your home).
 - Schedule. Cron expression. Cockpit shows the next 3 fire times so you can sanity-check.
 - Prompt. The instruction Claude runs on each fire.
-- Model and thinking level. Same options as interactive sessions.
+- Model, context size, and thinking level. Same options as interactive sessions, including custom [providers](settings.md#providers).
 - Enabled. Toggle to pause the job without deleting it.
 
 Save and the scheduler picks it up immediately.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -49,16 +49,30 @@ Messages render as they arrive:
 
 Long histories use windowed rendering. The initial view loads 50 messages, with 30 more fetched as you scroll up.
 
+## Tabbed layout
+
+A session view is a set of tabs. Alongside the chat you can open file, diff, and changes tabs, plus an [embedded terminal](terminal.md). On wider screens you can split into two panes and drag tabs between them. Tabs persist across page refreshes, so your layout comes back when you return.
+
 ## Session settings
 
 Each session has its own settings, separate from the defaults you set globally. Tap the settings icon next to the message box to change:
 
-- Model (Haiku, Sonnet, Opus, with version switcher)
-- Extended context (200K or 1M tokens)
-- Thinking level (Low, Medium, High, XHigh, Max)
-- Permission bypass for this session
+- Model. Built-in Haiku, Sonnet, and Opus with a version switcher, plus any models from your custom providers (see [Model providers](providers.md)).
+- Context size. 200K or 1M, shown as pills for models that support both.
+- Thinking level. Low, Medium, High, XHigh, Max. Only the levels the model supports are shown.
+- Runtime. Switch this session between Stream and PTY (see [Runtime mode](#runtime-mode)).
+- Permission bypass for this session.
 
-Changes apply on the next turn.
+Changes apply on the next turn. A context-size change restarts the underlying CLI, since the 1M switch is applied when the process spawns.
+
+## Runtime mode
+
+Cockpit can drive Claude Code two ways, chosen per session:
+
+- **Stream (headless).** The default. Cockpit runs the CLI in streaming-JSON mode and renders the structured event stream directly.
+- **PTY (interactive).** Cockpit runs the real CLI inside a pseudo-terminal, the same engine you get in a normal terminal. Message content is read from the CLI's JSONL transcript, so the live view matches a reload. Hook events drive status, permissions, compaction progress, and background tasks.
+
+Pick the runtime when you create a session (the new-session dialog has a two-step backend picker) or switch it later from the session settings. The choice is saved and survives a server restart.
 
 ## Attachments
 
@@ -95,6 +109,10 @@ Permissions are scoped per session, project, or globally. The Settings page has 
 ## Slash commands
 
 Type `/` to open the menu. Cockpit supports the same slash commands as Claude Code.
+
+## Prompt history
+
+Press the up arrow in an empty input to open the prompt history modal, Atuin-style. It lists prompts you have sent, newest first, and is searchable. Pick one to drop it back into the input. History is read from the full session transcript, not just the current view.
 
 ## Session linking via /clear
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -12,12 +12,17 @@ To reset the password: set `COCKPIT_RESET_PASSWORD=true` and restart.
 
 The Settings page picks the defaults for new sessions:
 
-- Model. Haiku, Sonnet, or Opus, with the version switcher for selecting between current and previous releases.
-- Extended context. 200K (default) or 1M tokens.
-- Thinking level. Low, Medium, High, XHigh, Max. Trades latency for depth of reasoning.
+- Model. Built-in Haiku, Sonnet, or Opus with a version switcher, or any model from a custom provider (see [Providers](#providers)). Models can be set per slot: main, subagent, and fast.
+- Context size. 200K (default) or 1M, for models that support both.
+- Thinking level. Low, Medium, High, XHigh, Max. Trades latency for depth of reasoning. Only the levels the model supports are offered.
+- Default runtime is Stream; choose Stream or PTY per session (see [Sessions: runtime mode](sessions.md#runtime-mode)).
 - Permission bypass. Off by default. When on, Claude skips permission prompts. An orange warning is shown when active.
 
 Existing sessions keep their own settings. Defaults only apply to new sessions.
+
+## Providers
+
+Beyond the built-in Anthropic models, you can configure custom Anthropic-compatible providers (proxies, gateways, alternate endpoints) from the Providers page, each with its own environment variables and model list. See [Model providers](providers.md) for the full walkthrough.
 
 ## UI preferences
 
@@ -28,9 +33,9 @@ Existing sessions keep their own settings. Defaults only apply to new sessions.
 - Reviews. On by default. Shows the Reviews section in the sidebar and enables PR review features. Turn off to hide reviews entirely.
 - Dismiss keyboard on send. On by default. Automatically dismisses the on-screen keyboard on mobile after sending a message.
 
-## Claude version
+## Versions and updates
 
-Settings shows the installed Claude Code CLI version and checks npm for the latest. The Update button installs the latest globally.
+Settings shows the installed versions of both Cockpit and the Claude Code CLI and checks npm for the latest of each. An Update button installs the latest globally, with native-install detection so it uses the right command for how you installed. Each one links to its changelog.
 
 ## Customizations
 
@@ -111,16 +116,30 @@ Inbox messages are stored in `~/.cockpit/inbox.jsonl`. When a message arrives, i
 | `PORT` | Server port | `3001` |
 | `HOST` | Bind address | `0.0.0.0` |
 | `COCKPIT_RESET_PASSWORD` | Force password reset on next startup | `false` |
+| `COCKPIT_CONFIG_DIR` | Location of Cockpit config (password, providers, defaults, jobs, inbox) | `~/.cockpit` |
+| `CLAUDE_CONFIG_DIR` | Location of Claude config and transcripts that Cockpit reads | `~/.claude` |
+| `COCKPIT_CACHE_DIR` | Location of per-session caches (hook settings, attachments) | `~/.cache/cockpit` |
+| `COCKPIT_DEBUG` | Set to `1` to write a structured debug log (see Troubleshooting) | unset |
+| `COCKPIT_TOKEN` | Auth-bypass token for automated/embedded use; requests presenting it skip the login. Keep it secret | unset |
+
+Setting `COCKPIT_CONFIG_DIR` and `CLAUDE_CONFIG_DIR` lets you run fully isolated Cockpit instances side by side.
 
 Claude Code's own environment variables (`ANTHROPIC_API_KEY`, etc.) are read by the CLI as normal.
 
 ## Paths
 
+Cockpit config paths are under `COCKPIT_CONFIG_DIR` (default `~/.cockpit`); Claude paths are under `CLAUDE_CONFIG_DIR` (default `~/.claude`).
+
 | Path | Used for |
 |---|---|
 | `~/.cockpit/password.json` | Password hash |
+| `~/.cockpit/providers.json` | Custom model providers |
+| `~/.cockpit/defaults.json` | Session defaults (model slots, context size, thinking level) |
 | `~/.cockpit/notifications.json` | Notification provider config |
 | `~/.cockpit/inbox.jsonl` | Inbox messages |
+| `~/.cockpit/scheduled-jobs.json` | Scheduled job definitions |
+| `~/.cockpit/job-runs/` | Scheduled job run history |
+| `~/.cockpit/job-locks/` | Scheduled job locks |
 | `~/.claude/cockpit/pinned_sessions.json` | Pinned session list |
 | `~/.claude/plans/` | Plan files written by Claude |
 | `~/.claude/agents/` | Global agents |

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -1,0 +1,30 @@
+# Embedded terminal
+
+Cockpit includes a full terminal in the browser, so you can run commands next to a session without leaving the UI. It is a real shell on the server (node-pty), rendered with xterm.js.
+
+## Opening a terminal
+
+Click the terminal button in the header (Ctrl+`) to open one. Terminals open as tabs in the session view and can be split across panes like any other tab (see [Sessions](sessions.md#tabbed-layout)). The shell starts in the active session's working directory.
+
+The shell is detected from the host: the login shell from `getent passwd` on Linux or `dscl` on macOS, falling back to `$SHELL` or `/bin/sh`.
+
+## Settings
+
+Open the terminal settings modal from the panel to adjust:
+
+- **Theme.** 10 presets, including a Cockpit theme that matches the app and common choices like Dracula, Catppuccin, Tokyo Night, Nord, Gruvbox, Solarized, Monokai, and One Dark.
+- **Font size.**
+- **Scrollback.** Number of lines retained.
+
+Changes apply live without restarting the shell.
+
+## Behaviour
+
+- **Scrollback survives tab moves.** Terminal instances are cached across React remounts, so dragging a terminal tab between panes or toggling split view keeps its history.
+- **Reconnect.** If the backend terminal goes away, the panel offers a reconnect that starts a fresh shell in the same directory.
+- **Mobile.** A toolbar exposes keys that are awkward on a touch keyboard (arrows, Esc, Tab, Ctrl). Keyboard open/close is detected with the visualViewport API so the layout reflows cleanly.
+
+## Notes
+
+- Terminals are served over a dedicated WebSocket, separate from the session stream.
+- Nerd Font glyphs render if a Nerd Font is installed and selected by your browser's monospace font.


### PR DESCRIPTION
Brings README and docs/ up to date with the 0.3.0 release.

New docs:
- docs/providers.md — built-in + custom Anthropic-compatible providers, model slots, context sizes
- docs/terminal.md — embedded xterm.js terminal (themes, scrollback, mobile)

Updated:
- sessions.md — Runtime mode (Stream vs PTY), Tabbed layout, Prompt history; fixed stale 'Extended context' wording
- settings.md — Providers section, per-slot models, Cockpit self-update, missing env vars (COCKPIT_CONFIG_DIR, CLAUDE_CONFIG_DIR, COCKPIT_CACHE_DIR, COCKPIT_TOKEN, COCKPIT_DEBUG), storage paths
- scheduled-jobs.md — custom-provider model selection
- README — overview, config table, and doc links

Docs-only; no code changes. Cross-doc anchor links verified.