### PR TITLE
fix: structured questions getting stuck (rendering + slow-answer hang)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.1] - 2026-05-30
 
 ### Fixed
 - **Structured questions getting stuck (rendering).** A follow-up `AskUserQuestion` asked right after the previous one was answered now renders instead of staying hidden (blue sidebar status, no prompt) until you pressed stop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Structured questions getting stuck (rendering).** A follow-up `AskUserQuestion` asked right after the previous one was answered now renders instead of staying hidden (blue sidebar status, no prompt) until you pressed stop.
+- **Structured questions getting stuck (slow answers).** Answering a question more than five minutes after it appeared (for example after switching browser tabs) no longer hangs the session. In PTY mode the hook bridge held the CLI's blocking permission request open with the global `fetch`, which Node aborts after a five-minute headers timeout, so a late answer landed on a dead connection and the CLI waited forever. The bridge now uses a plain HTTP request with no such ceiling, waits as long as the CLI's own permission timeout, and always returns a decision so the CLI can never hang without one.
+
 ## [0.3.0] - 2026-05-30
 
 ### Added

--- a/bin/cockpit-hook-bridge.mjs
+++ b/bin/cockpit-hook-bridge.mjs
@@ -11,9 +11,23 @@
  *   COCKPIT_HOOK_TOKEN    per-session token
  *   COCKPIT_SESSION_ID    cockpit's internal session id
  *
+ * Optional tuning (milliseconds):
+ *   COCKPIT_PERMISSION_HOOK_TIMEOUT_MS  how long to wait for a permission/question
+ *                                       answer before giving up (default 24h)
+ *   COCKPIT_HOOK_TIMEOUT_MS             how long to wait for any other hook (default 60s)
+ *
  * Usage: cockpit-hook-bridge <eventName>
  *   eventName ∈ {PreToolUse, PostToolUse, Stop, UserPromptSubmit, Notification, PermissionRequest}
+ *
+ * NOTE: this uses node:http directly rather than the global fetch(). fetch is
+ * undici, whose default headersTimeout/bodyTimeout are 5 minutes, so a held
+ * PermissionRequest response (the CLI blocks while the user decides) was aborted
+ * after 5 minutes — the CLI then hung with no decision and the user's eventual
+ * answer landed on a dead socket. node:http only times out on the explicit cap
+ * below, so a permission prompt can wait as long as the CLI's own hook timeout.
  */
+
+import { request as httpRequest } from "node:http";
 
 const eventName = process.argv[2];
 if (!eventName) {
@@ -29,6 +43,29 @@ if (!url || !token || !sessionId) {
   process.exit(0);
 }
 
+function envMs(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+// A permission/question can block on the user for a long time. Match the CLI's
+// own permission hook timeout (24h) rather than fetch's hidden 5-minute ceiling.
+const TIMEOUT_MS =
+  eventName === "PermissionRequest"
+    ? envMs("COCKPIT_PERMISSION_HOOK_TIMEOUT_MS", 24 * 60 * 60 * 1000)
+    : envMs("COCKPIT_HOOK_TIMEOUT_MS", 60 * 1000);
+
+function permissionDenyJson(message) {
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PermissionRequest",
+      decision: { behavior: "deny", message },
+    },
+  });
+}
+
 async function readStdin() {
   if (process.stdin.isTTY) return "";
   process.stdin.setEncoding("utf8");
@@ -37,14 +74,51 @@ async function readStdin() {
   return body;
 }
 
-const TIMEOUT_MS = eventName === "PermissionRequest" ? 10 * 60 * 1000 : 60 * 1000;
+/**
+ * POST the payload and resolve with { status, body }. Rejects on transport
+ * error or when the request exceeds TIMEOUT_MS with no response.
+ */
+function postHook(target, payload) {
+  return new Promise((resolve, reject) => {
+    let parsed;
+    try {
+      parsed = new URL(target);
+    } catch (err) {
+      reject(err);
+      return;
+    }
 
-function permissionDenyJson() {
-  return JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: "PermissionRequest",
-      decision: { behavior: "deny", message: "hook bridge timed out waiting for cockpit" },
-    },
+    const req = httpRequest(
+      {
+        protocol: parsed.protocol,
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname + parsed.search,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+          "X-Cockpit-Session": sessionId,
+          "X-Cockpit-Token": token,
+        },
+      },
+      (res) => {
+        res.setEncoding("utf8");
+        let data = "";
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
+      },
+    );
+
+    // The socket sits idle while the user decides; this is the only ceiling on
+    // how long we wait for the response.
+    req.setTimeout(TIMEOUT_MS, () => {
+      req.destroy(Object.assign(new Error("timed out waiting for cockpit"), { code: "ETIMEDOUT" }));
+    });
+    req.on("error", reject);
+    req.end(payload);
   });
 }
 
@@ -54,38 +128,33 @@ async function main() {
 
   let res;
   try {
-    res = await fetch(target, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Cockpit-Session": sessionId,
-        "X-Cockpit-Token": token,
-      },
-      body: body || "{}",
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-    });
+    res = await postHook(target, body || "{}");
   } catch (err) {
     const msg = err && err.message ? err.message : String(err);
-    const isTimeout = err && err.name === "TimeoutError";
-    process.stderr.write(`cockpit-hook-bridge: request ${isTimeout ? "timed out" : "failed"}: ${msg}\n`);
-    if (isTimeout && eventName === "PermissionRequest") {
-      process.stdout.write(permissionDenyJson());
+    const timedOut = err && err.code === "ETIMEDOUT";
+    process.stderr.write(`cockpit-hook-bridge: request ${timedOut ? "timed out" : "failed"}: ${msg}\n`);
+    // A permission request must always yield a decision, or the CLI hangs.
+    if (eventName === "PermissionRequest") {
+      process.stdout.write(permissionDenyJson(`hook bridge ${timedOut ? "timed out waiting for" : "could not reach"} cockpit`));
     }
     process.exit(0);
   }
 
-  if (!res.ok) {
+  if (res.status < 200 || res.status >= 300) {
     process.stderr.write(`cockpit-hook-bridge: router returned ${res.status}\n`);
     if (eventName === "PermissionRequest") {
-      process.stdout.write(permissionDenyJson());
+      process.stdout.write(permissionDenyJson(`hook router returned ${res.status}`));
     }
     process.exit(0);
   }
 
   let parsed;
   try {
-    parsed = await res.json();
+    parsed = JSON.parse(res.body);
   } catch {
+    if (eventName === "PermissionRequest") {
+      process.stdout.write(permissionDenyJson("hook router sent an unreadable response"));
+    }
     process.exit(0);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alexjbarnes/cockpit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alexjbarnes/cockpit",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alexjbarnes/cockpit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Web UI for Claude Code",
   "license": "Apache-2.0",
   "author": "Alex Barnes (https://github.com/alexjbarnes)",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -376,7 +376,10 @@ export function ChatView({
               const { before, questionBlock, after } = splitAtQuestion(msg.blocks || []);
 
               if (questionBlock) {
-                const pending = pendingQuestions.find(() => true);
+                // Match an UNANSWERED pending question. find(() => true) grabbed
+                // the first entry, which after a prior answered question is the
+                // stale answered one — so a follow-up question never rendered.
+                const pending = pendingQuestions.find((q) => !q.answered);
                 const hasOutput = !!questionBlock.toolUse.output;
                 console.log(
                   `[question-debug] Place1 render: msgId=${msg.id.slice(0, 8)}, hasOutput=${hasOutput}, pending=${!!pending}, pendingCount=${pendingQuestions.length}`,
@@ -478,21 +481,28 @@ export function ChatView({
               <PermissionPrompt key={p.requestId} permission={p} onRespond={respondToPermission} />
             ),
           )}
-          {pendingQuestions.length > 0 &&
+          {pendingQuestions.some((q) => !q.answered) &&
             (() => {
-              const hasInline = visibleMessages.some(
+              // Only an UNANSWERED inline block (no output) means Place1 is
+              // already showing the prompt. An answered block (output set)
+              // renders as a QuestionCard and must NOT suppress a new question's
+              // standalone prompt — that stranded follow-up questions.
+              const hasUnansweredInline = visibleMessages.some(
                 (m) =>
-                  m.role === "assistant" && (m.blocks || []).some((b) => b.type === "tool_use" && b.toolUse.name === "AskUserQuestion"),
+                  m.role === "assistant" &&
+                  (m.blocks || []).some((b) => b.type === "tool_use" && b.toolUse.name === "AskUserQuestion" && !b.toolUse.output),
               );
-              return !hasInline;
+              return !hasUnansweredInline;
             })() &&
-            pendingQuestions.map((q) => (
-              <div key={q.requestId} className="flex w-full justify-start">
-                <div className="max-w-[85%]">
-                  <QuestionPrompt questions={parseQuestionsFromInput(q.questions)} onSubmit={respondToQuestion} requestId={q.requestId} />
+            pendingQuestions
+              .filter((q) => !q.answered)
+              .map((q) => (
+                <div key={q.requestId} className="flex w-full justify-start">
+                  <div className="max-w-[85%]">
+                    <QuestionPrompt questions={parseQuestionsFromInput(q.questions)} onSubmit={respondToQuestion} requestId={q.requestId} />
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
           {modelPicker !== null && (
             <ModelPicker
               currentModel={modelPicker}

--- a/tests/hook-bridge.test.ts
+++ b/tests/hook-bridge.test.ts
@@ -1,0 +1,175 @@
+// Regression tests for bin/cockpit-hook-bridge.mjs.
+//
+// The bridge posts each Claude hook to cockpit's hook-router and waits for the
+// response. For PermissionRequest the router holds that response open until the
+// user answers the AskUserQuestion — which can be many minutes. The bridge used
+// to use the global fetch(); Node's fetch is undici, whose default
+// headersTimeout/bodyTimeout are 5 minutes, so a slow answer aborted the request
+// and the CLI hung with no decision (and the user's eventual click landed on a
+// dead socket). The bridge now uses node:http, whose only ceiling is the explicit
+// timeout below, and always emits a deny decision on failure so the CLI never
+// hangs waiting for a decision that will never come.
+
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const BRIDGE = path.resolve(process.cwd(), "bin/cockpit-hook-bridge.mjs");
+const TOKEN = "test-token";
+const SESSION = "test-session-id";
+
+interface RouterBehaviour {
+  /** ms to hold the response before replying */
+  hold?: number;
+  /** status code to send (default 200) */
+  status?: number;
+  /** JSON body to send */
+  body?: unknown;
+}
+
+function startRouter(behaviour: RouterBehaviour): Promise<{ url: string; server: Server }> {
+  const server = createServer((req, res) => {
+    // drain request body, then apply the behaviour
+    req.on("data", () => {});
+    req.on("end", () => {
+      const reply = () => {
+        res.statusCode = behaviour.status ?? 200;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(behaviour.body ?? {}));
+      };
+      if (behaviour.hold && behaviour.hold > 0) setTimeout(reply, behaviour.hold);
+      else reply();
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ url: `http://127.0.0.1:${port}`, server });
+    });
+  });
+}
+
+interface BridgeResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  elapsedMs: number;
+}
+
+function runBridge(eventName: string, opts: { hookUrl: string; payload?: string; env?: Record<string, string> }): Promise<BridgeResult> {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const child = spawn(process.execPath, [BRIDGE, eventName], {
+      env: {
+        ...process.env,
+        COCKPIT_HOOK_URL: opts.hookUrl,
+        COCKPIT_HOOK_TOKEN: TOKEN,
+        COCKPIT_SESSION_ID: SESSION,
+        ...opts.env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => (stdout += c));
+    child.stderr.on("data", (c) => (stderr += c));
+    child.on("close", (code) => resolve({ code, stdout, stderr, elapsedMs: Date.now() - start }));
+    child.stdin.end(opts.payload ?? "{}");
+  });
+}
+
+let active: Server | null = null;
+afterEach(async () => {
+  if (active) {
+    await new Promise<void>((r) => active!.close(() => r()));
+    active = null;
+  }
+});
+
+describe("cockpit-hook-bridge", () => {
+  it("returns the router's decision for a permission response held open", async () => {
+    const decision = JSON.stringify({
+      hookSpecificOutput: { hookEventName: "PermissionRequest", decision: { behavior: "allow" } },
+    });
+    const { url, server } = await startRouter({ hold: 1500, body: { stdout: decision, exitCode: 0 } });
+    active = server;
+
+    const r = await runBridge("PermissionRequest", { hookUrl: url });
+
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe(decision);
+    // It actually waited for the held response rather than bailing early.
+    expect(r.elapsedMs).toBeGreaterThanOrEqual(1400);
+  });
+
+  it("emits a deny decision when the answer exceeds the permission timeout", async () => {
+    // Router never replies in time; the bridge's own cap fires.
+    const { url, server } = await startRouter({ hold: 5000, body: { stdout: "late", exitCode: 0 } });
+    active = server;
+
+    const r = await runBridge("PermissionRequest", {
+      hookUrl: url,
+      env: { COCKPIT_PERMISSION_HOOK_TIMEOUT_MS: "600" },
+    });
+
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.hookSpecificOutput.decision.behavior).toBe("deny");
+    // Timed out at ~600ms, did not wait the full 5s hold.
+    expect(r.elapsedMs).toBeLessThan(3000);
+  });
+
+  it("emits a deny decision when the router returns a non-2xx", async () => {
+    const { url, server } = await startRouter({ status: 500, body: {} });
+    active = server;
+
+    const r = await runBridge("PermissionRequest", { hookUrl: url });
+
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout).hookSpecificOutput.decision.behavior).toBe("deny");
+  });
+
+  it("emits a deny decision when cockpit is unreachable", async () => {
+    // Bind then immediately close to get a port that refuses connections.
+    const { url, server } = await startRouter({});
+    await new Promise<void>((r) => server.close(() => r()));
+
+    const r = await runBridge("PermissionRequest", { hookUrl: url });
+
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout).hookSpecificOutput.decision.behavior).toBe("deny");
+  });
+
+  it("passes through stdout and exit code for non-permission hooks", async () => {
+    const { url, server } = await startRouter({ body: { stdout: "from-router", exitCode: 2 } });
+    active = server;
+
+    const r = await runBridge("PreToolUse", { hookUrl: url });
+
+    expect(r.code).toBe(2);
+    expect(r.stdout).toBe("from-router");
+  });
+
+  // The original bug: a permission response held longer than undici's 5-minute
+  // fetch ceiling. node:http has no such ceiling. Slow (>5 min); opt in with
+  // RUN_SLOW_HOOK_TESTS=1.
+  it.skipIf(!process.env.RUN_SLOW_HOOK_TESTS)(
+    "tolerates a permission response held past undici's 5-minute fetch ceiling",
+    async () => {
+      const decision = JSON.stringify({
+        hookSpecificOutput: { hookEventName: "PermissionRequest", decision: { behavior: "allow" } },
+      });
+      const { url, server } = await startRouter({ hold: 320_000, body: { stdout: decision, exitCode: 0 } });
+      active = server;
+
+      const r = await runBridge("PermissionRequest", { hookUrl: url });
+
+      expect(r.code).toBe(0);
+      expect(r.stdout).toBe(decision);
+      expect(r.elapsedMs).toBeGreaterThan(300_000);
+    },
+    360_000,
+  );
+});

--- a/tests/integration/sequential-questions.spec.ts
+++ b/tests/integration/sequential-questions.spec.ts
@@ -1,0 +1,95 @@
+// Regression: a second AskUserQuestion asked after the first was answered must
+// render. Reported as "ask me another question" getting stuck — the chat showed
+// a blue sidebar (server holds the request) but no prompt; pressing stop
+// surfaced it.
+//
+// Root cause was in chat-view's two render paths. After answering the first
+// question, its assistant message keeps an AskUserQuestion tool_use block (now
+// with output). For the follow-up question:
+//   - Place1 (inline) used pendingQuestions.find(() => true), which returned the
+//     stale answered entry instead of the new one.
+//   - Place2 (standalone) was suppressed because hasInline matched the first
+//     question's now-answered block, and it also mapped answered entries.
+// Net: the follow-up question (only present in pendingQuestions, with no inline
+// block of its own yet) rendered nowhere. Single-question tests never hit it.
+
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { askUserQuestionResponse } from "../mock-api/builder";
+import { expect, test } from "./fixtures";
+
+const CLAUDE_BIN = process.env.CLAUDE_BIN ?? "claude";
+const CLAUDE_AVAILABLE = (() => {
+  try {
+    execSync(`${CLAUDE_BIN} --version`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+test.skip(!CLAUDE_AVAILABLE, `claude binary not found at ${CLAUDE_BIN} (set CLAUDE_BIN env)`);
+
+test("a follow-up question renders after the first one is answered", async ({ page, harness }) => {
+  const workDir = mkdtempSync(path.join(tmpdir(), "cockpit-it-seqq-"));
+  mkdirSync(path.join(workDir, ".git"), { recursive: true });
+
+  try {
+    harness.mock.setScript([
+      {
+        events: askUserQuestionResponse([
+          {
+            question: "What color?",
+            header: "Color",
+            multiSelect: false,
+            options: [
+              { label: "Red", description: "Like a rose" },
+              { label: "Blue", description: "Like the sky" },
+            ],
+          },
+        ]),
+      },
+      {
+        events: askUserQuestionResponse([
+          {
+            question: "Which size?",
+            header: "Size",
+            multiSelect: false,
+            options: [
+              { label: "Small", description: "Compact" },
+              { label: "Large", description: "Roomy" },
+            ],
+          },
+        ]),
+      },
+    ]);
+
+    const createRes = await page.request.post(`${harness.cockpitUrl}/api/sessions`, {
+      data: { cwd: workDir, runtime: "pty" },
+    });
+    const { sessionId } = await createRes.json();
+    await page.goto(`${harness.cockpitUrl}/sessions/${sessionId}?cwd=${encodeURIComponent(workDir)}`);
+    await expect(page.getByTestId("message-input")).toBeVisible();
+    await page.waitForTimeout(5000);
+
+    // First question.
+    await page.getByTestId("message-input").fill("hi");
+    await page.getByTestId("btn-send").click();
+    await expect(page.getByText("What color?")).toBeVisible({ timeout: 30_000 });
+
+    // Answer it (select an option, then Submit); the CLI then asks the second
+    // question.
+    await page.getByRole("button", { name: /Red/ }).first().click();
+    await page.getByRole("button", { name: /^Submit$/ }).click();
+
+    // The follow-up question must render (pre-fix it stayed hidden behind the
+    // first question's answered block).
+    await expect(page.getByText("Which size?")).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByRole("button", { name: /Small/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Large/ })).toBeVisible();
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Two distinct root causes behind the recurring "structured question doesn't show / session stuck on running" reports. Both fixed here.

## 1. Rendering (commit 1e458d2)
A follow-up `AskUserQuestion` asked right after the previous one was answered rendered nowhere (blue sidebar status, no prompt) until you pressed stop. `chat-view.tsx`'s two render paths mishandled an already-answered question still present in `pendingQuestions`/`visibleMessages`:
- Place1 used `pendingQuestions.find(() => true)`, returning the stale **answered** entry.
- Place2 was suppressed by the first question's now-answered inline block and also mapped answered entries.

Fix: Place1 uses `find(q => !q.answered)`; Place2 gates on `some(q => !q.answered)`, only counts inline blocks with no output, and maps `filter(q => !q.answered)`. Regression: `tests/integration/sequential-questions.spec.ts`.

## 2. Slow-answer hang (commit 6b37e96)
Answering a question more than **5 minutes** after it appeared (e.g. after switching tabs) hung the session. In PTY mode the CLI's blocking `PermissionRequest` is held open by the hook bridge, which used the global `fetch`. Node's `fetch` is undici, whose default `headersTimeout`/`bodyTimeout` are 300s, so a slow answer had its held request aborted: the CLI was left with no decision (stuck on "running") and the eventual click landed on a dead socket. undici's abort is a `TypeError`, not a `TimeoutError`, so the bridge's deny-fallback never fired either.

Evidence from a live `debug.jsonl`: every answer under 5 min produced a `tool_result` and worked (4s/6s/14s/58s/103s); every answer over 5 min produced none and hung (7.3 min, ~13 min).

Fix: the bridge uses `node:http` (no hidden response ceiling), waits up to the CLI's own permission timeout (24h, env-overridable), and always returns a decision on any failure. Regression: `tests/hook-bridge.test.ts` (5 fast tests + a slow opt-in test that holds a response 320s, verified passing).

Full unit suite (1408) green, typecheck clean.