### PR TITLE
fix: open files in a session tab from diff/changes 'Open in editor'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **File links open in a tab.** The "Open in editor" link on a diff or changes panel now opens the file in a session tab, matching file links in tool cards and the file tree, instead of leaving the session for the standalone full-page `/files` viewer. The full-page viewer is still used when there is no session to host a tab (for example PR review).
+
 ## [0.3.1] - 2026-05-30
 
 ### Fixed

--- a/src/components/changes-view.tsx
+++ b/src/components/changes-view.tsx
@@ -457,7 +457,7 @@ export function ChangesView({
   manageSidebar?: boolean;
 }) {
   const { settings } = useSettings();
-  const { setSidebarSection, removeSidebarSection, closeSidebar } = useShell();
+  const { setSidebarSection, removeSidebarSection, closeSidebar, tabActions } = useShell();
   const { send, subscribe } = useWebSocket();
   const router = useRouter();
   const isDesktop = useIsDesktop();
@@ -748,9 +748,15 @@ export function ChangesView({
   const handleViewFile = useCallback(
     (filePath: string) => {
       const fullPath = filePath.startsWith("/") ? filePath : `${cwd}/${filePath}`;
-      router.push(`/files?cwd=${encodeURIComponent(cwd)}&file=${encodeURIComponent(fullPath)}`);
+      // Inside a session, open the file as a tab; only fall back to the
+      // standalone /files page when there's no tab context.
+      if (tabActions) {
+        tabActions.openFile(fullPath);
+      } else {
+        router.push(`/files?cwd=${encodeURIComponent(cwd)}&file=${encodeURIComponent(fullPath)}`);
+      }
     },
-    [cwd, router],
+    [cwd, router, tabActions],
   );
 
   useEffect(() => {

--- a/src/components/diff-view.tsx
+++ b/src/components/diff-view.tsx
@@ -6,6 +6,7 @@ import { FileDiff } from "@pierre/diffs/react";
 import { Check, ExternalLink, FileEdit, FileMinus, FilePlus, FileSymlink, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useShell } from "@/components/app-shell";
 import { DIFF_SELECTABLE_CSS, DiffErrorBoundary } from "@/components/diff-viewer";
 import { useSettings } from "@/hooks/use-settings";
 import { useWebSocket } from "@/hooks/use-websocket";
@@ -57,6 +58,7 @@ interface DiffViewProps {
 export function DiffView({ cwd, filePath }: DiffViewProps) {
   const { settings } = useSettings();
   const router = useRouter();
+  const { tabActions } = useShell();
   const { subscribe } = useWebSocket();
   const [loading, setLoading] = useState(true);
   const [diff, setDiff] = useState<string | null>(null);
@@ -137,8 +139,14 @@ export function DiffView({ cwd, filePath }: DiffViewProps) {
 
   const handleViewFile = useCallback(() => {
     const fullPath = filePath.startsWith("/") ? filePath : `${cwd}/${filePath}`;
-    router.push(`/files?cwd=${encodeURIComponent(cwd)}&file=${encodeURIComponent(fullPath)}`);
-  }, [cwd, filePath, router]);
+    // Inside a session, open the file as a tab; only fall back to the
+    // standalone /files page when there's no tab context (e.g. PR review).
+    if (tabActions) {
+      tabActions.openFile(fullPath);
+    } else {
+      router.push(`/files?cwd=${encodeURIComponent(cwd)}&file=${encodeURIComponent(fullPath)}`);
+    }
+  }, [cwd, filePath, router, tabActions]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Problem
Clicking the **"Open in editor"** link in a diff panel (or the changes view) navigated out of the session to the standalone full-page `/files` viewer, instead of opening the file as a tab in the session. Reported with screenshots: the link jumped from `/sessions/...` (tabbed view) to `/files?cwd=...`.

## Cause
`diff-view.tsx` (`handleViewFile`) and `changes-view.tsx` (`handleViewFile`) always did `router.push('/files...')`. The equivalent links in `tool-card.tsx` and the sidebar file tree already prefer `tabActions.openFile()` when inside a session and only fall back to `/files` when there's no tab context.

## Fix
Apply that same pattern to `diff-view` and `changes-view`: open the file as a tab via `tabActions.openFile(fullPath)` when a session tab context exists, falling back to the full-page `/files` viewer otherwise (e.g. PR review, standalone pages). `useShell()` reads from a context with a safe default (`tabActions: null`), so the fallback is preserved everywhere `diff-view` renders.

Typecheck + lint clean. Not yet exercised in a browser — see verification note in the PR thread.