### PR TITLE
Cockpit agent single persistent session

### DIFF
--- a/src/app/(app)/settings/assistant/page.tsx
+++ b/src/app/(app)/settings/assistant/page.tsx
@@ -86,7 +86,7 @@ export default function AssistantSettingsPage() {
         await fetch("/api/assistant-settings", {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(next),
+          body: JSON.stringify(partial),
         });
       } catch {
         // best effort

--- a/src/app/api/assistant-session/route.ts
+++ b/src/app/api/assistant-session/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateSession } from "@/server/auth";
+import { getCockpitDir } from "@/server/paths";
+import { getSessionManager } from "@/server/singleton";
+
+function authenticate(req: NextRequest): boolean {
+  const token = req.cookies.get("cockpit_session")?.value || req.headers.get("authorization")?.replace("Bearer ", "");
+  return !!token && validateSession(token);
+}
+
+export async function GET(req: NextRequest) {
+  if (!authenticate(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const sessionId = await getSessionManager().getOrCreateCockpitAgentSession();
+  return NextResponse.json({ sessionId, cwd: getCockpitDir() });
+}

--- a/src/app/api/assistant-settings/route.ts
+++ b/src/app/api/assistant-settings/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAssistantSettings, updateAssistantSettings } from "@/server/assistant-settings";
+import type { ContextSize } from "@/lib/models";
+import { type AssistantSettings, getAssistantSettings, updateAssistantSettings } from "@/server/assistant-settings";
 import { validateSession } from "@/server/auth";
+import { getSessionManager } from "@/server/singleton";
+import type { ThinkingLevel } from "@/types";
 
 function authenticate(req: NextRequest): boolean {
   const token = req.cookies.get("cockpit_session")?.value || req.headers.get("authorization")?.replace("Bearer ", "");
@@ -20,6 +23,20 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const body = await req.json();
-  const updated = updateAssistantSettings(body);
+  // Only the settings-page fields are accepted from the client. sessionId is
+  // server-managed (written by the resolver); a PATCH body must never overwrite it.
+  const partial: Partial<AssistantSettings> = {};
+  if (typeof body.model === "string" && body.model) partial.model = body.model;
+  if (typeof body.thinkingLevel === "string" && body.thinkingLevel) {
+    partial.thinkingLevel = body.thinkingLevel as ThinkingLevel;
+  }
+  if (body.runtime === "stream" || body.runtime === "pty") partial.runtime = body.runtime;
+  if (body.contextSize === "200k" || body.contextSize === "1m") partial.contextSize = body.contextSize as ContextSize;
+  const updated = updateAssistantSettings(partial);
+  await getSessionManager().applyCockpitAgentSettings({
+    model: partial.model,
+    thinkingLevel: partial.thinkingLevel,
+    contextSize: partial.contextSize,
+  });
   return NextResponse.json(updated);
 }

--- a/src/app/api/sessions/group/route.ts
+++ b/src/app/api/sessions/group/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { validateSession } from "@/server/auth";
+import { getCockpitDir } from "@/server/paths";
 import { getSessionManager } from "@/server/singleton";
 import { scanSessionsForCwd } from "@/server/transcript";
 import type { SessionInfo } from "@/types";
@@ -17,6 +18,10 @@ export async function GET(req: NextRequest) {
   const cwd = req.nextUrl.searchParams.get("cwd");
   if (!cwd) {
     return NextResponse.json({ error: "cwd is required" }, { status: 400 });
+  }
+
+  if (cwd === getCockpitDir()) {
+    return NextResponse.json({ sessions: [] });
   }
 
   const sessions = await scanSessionsForCwd(cwd);

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { NextRequest, NextResponse } from "next/server";
 import { validateSession } from "@/server/auth";
 import { debugLog } from "@/server/debug-logger";
+import { getCockpitDir } from "@/server/paths";
 import { getSessionManager } from "@/server/singleton";
 import { scanAllSessions } from "@/server/transcript";
 
@@ -44,8 +45,11 @@ export async function GET(req: NextRequest) {
     }
   }
 
+  const cockpitConfigDir = getCockpitDir();
+
   // Include in-memory sessions that have no transcript file yet
   for (const mem of known) {
+    if (mem.cwd === cockpitConfigDir) continue;
     if (onDiskIds.has(mem.id)) continue;
     const group = groups.find((g) => g.cwd === mem.cwd);
     if (group) {
@@ -71,7 +75,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ sessions: allReviews.slice(0, limit) });
   }
 
-  const filtered = groups.filter((g) => g.sessions.length > 0 && !g.cwd.endsWith(".cockpit/jobs"));
+  const filtered = groups.filter((g) => g.sessions.length > 0 && !g.cwd.endsWith(".cockpit/jobs") && g.cwd !== cockpitConfigDir);
 
   // Re-sort after merging in-memory sessions
   for (const group of filtered) {

--- a/src/components/assistant-modal.tsx
+++ b/src/components/assistant-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bot, Loader2 } from "lucide-react";
+import { Bot, Loader2, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { ChatView } from "./chat-view";
@@ -84,6 +84,14 @@ export function AssistantModal({ open, onOpenChange }: AssistantModalProps) {
         <div className="flex items-center gap-2 px-4 py-3 border-b shrink-0">
           <Bot className="h-4 w-4 text-muted-foreground" />
           <span className="text-sm font-medium">Cockpit Assistant</span>
+          <button
+            type="button"
+            onClick={() => handleOpenChange(false)}
+            aria-label="Close assistant"
+            className="ml-auto rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100"
+          >
+            <X className="h-4 w-4" />
+          </button>
         </div>
         <div className="flex-1 min-h-0 flex flex-col">
           {loading && (
@@ -92,7 +100,7 @@ export function AssistantModal({ open, onOpenChange }: AssistantModalProps) {
             </div>
           )}
           {error && <div className="flex items-center justify-center h-full text-sm text-muted-foreground px-4">{error}</div>}
-          {sessionId && !loading && !error && <ChatView sessionId={sessionId} cwd={cwd} />}
+          {sessionId && !loading && !error && <ChatView sessionId={sessionId} cwd={cwd} showPlanToggle={false} />}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/assistant-modal.tsx
+++ b/src/components/assistant-modal.tsx
@@ -41,35 +41,9 @@ export function AssistantModal({ open, onOpenChange }: AssistantModalProps) {
 
     async function init() {
       try {
-        // Fetch cwd and settings
-        const [cwdRes, settingsRes] = await Promise.all([fetch("/api/config/cwd"), fetch("/api/assistant-settings")]);
-
-        if (!cwdRes.ok || !settingsRes.ok) {
-          throw new Error("Failed to initialize assistant");
-        }
-
-        const { cwd: cockpitCwd } = await cwdRes.json();
-        const settings = await settingsRes.json();
-
-        // Create cockpit-agent session
-        const sessionRes = await fetch("/api/sessions", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            cwd: cockpitCwd,
-            cockpitAgent: true,
-            model: settings.model || "sonnet",
-            thinkingLevel: settings.thinkingLevel || "high",
-            runtime: settings.runtime,
-            contextSize: settings.contextSize,
-          }),
-        });
-
-        if (!sessionRes.ok) {
-          throw new Error("Failed to create assistant session");
-        }
-
-        const { sessionId: newId } = await sessionRes.json();
+        const res = await fetch("/api/assistant-session");
+        if (!res.ok) throw new Error("Failed to initialize assistant");
+        const { sessionId: newId, cwd: cockpitCwd } = await res.json();
         if (!cancelled) {
           sessionIdRef.current = newId;
           setSessionId(newId);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -33,6 +33,7 @@ export function ChatView({
   historyView,
   onSendMessage,
   className,
+  showPlanToggle = true,
 }: {
   sessionId: string;
   cwd?: string;
@@ -41,6 +42,7 @@ export function ChatView({
   historyView?: boolean;
   onSendMessage?: (fn: (text: string) => void) => void;
   className?: string;
+  showPlanToggle?: boolean;
 }) {
   const {
     messages,
@@ -551,6 +553,7 @@ export function ChatView({
           onSetBypass={setBypassAll}
           planMode={planMode}
           onSetPlanMode={setPlanMode}
+          showPlanToggle={showPlanToggle}
           thinkingLevel={thinkingLevel}
           onSetThinking={setThinkingLevel}
           currentModel={currentModel}

--- a/src/components/input-area.tsx
+++ b/src/components/input-area.tsx
@@ -225,6 +225,7 @@ interface InputAreaProps {
   onSetBypass: (enabled: boolean) => void;
   planMode: boolean;
   onSetPlanMode: (enabled: boolean) => void;
+  showPlanToggle?: boolean;
   thinkingLevel: ThinkingLevel;
   onSetThinking: (level: ThinkingLevel) => void;
   currentModel: string;
@@ -278,6 +279,7 @@ export function InputArea({
   onSetBypass,
   planMode,
   onSetPlanMode,
+  showPlanToggle = true,
   thinkingLevel,
   onSetThinking,
   currentModel,
@@ -500,7 +502,7 @@ export function InputArea({
         }
       }
 
-      if (e.key === "Tab" && !e.shiftKey) {
+      if (e.key === "Tab" && !e.shiftKey && showPlanToggle) {
         e.preventDefault();
         onSetPlanMode(!planMode);
         return;
@@ -539,6 +541,7 @@ export function InputArea({
       onInterrupt,
       planMode,
       onSetPlanMode,
+      showPlanToggle,
       promptHistory,
     ],
   );
@@ -1283,18 +1286,20 @@ export function InputArea({
                 <Send className="h-4 w-4" />
               </Button>
             )}
-            <button
-              onClick={() => onSetPlanMode(!planMode)}
-              title={planMode ? "Switch to Build mode (Tab)" : "Switch to Plan mode (Tab)"}
-              className={`mt-4 flex items-center gap-0.5 whitespace-nowrap rounded-full px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
-                planMode
-                  ? "bg-blue-500/15 text-blue-500 hover:bg-blue-500/25"
-                  : "bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground"
-              }`}
-            >
-              {planMode ? <Eye className="h-2.5 w-2.5" /> : <Hammer className="h-2.5 w-2.5" />}
-              {planMode ? "Plan" : "Build"}
-            </button>
+            {showPlanToggle && (
+              <button
+                onClick={() => onSetPlanMode(!planMode)}
+                title={planMode ? "Switch to Build mode (Tab)" : "Switch to Plan mode (Tab)"}
+                className={`mt-4 flex items-center gap-0.5 whitespace-nowrap rounded-full px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                  planMode
+                    ? "bg-blue-500/15 text-blue-500 hover:bg-blue-500/25"
+                    : "bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground"
+                }`}
+              >
+                {planMode ? <Eye className="h-2.5 w-2.5" /> : <Hammer className="h-2.5 w-2.5" />}
+                {planMode ? "Plan" : "Build"}
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/server/assistant-settings.ts
+++ b/src/server/assistant-settings.ts
@@ -9,6 +9,7 @@ export interface AssistantSettings {
   thinkingLevel: ThinkingLevel;
   runtime?: "stream" | "pty";
   contextSize?: ContextSize;
+  sessionId?: string;
 }
 
 const fallback: AssistantSettings = {

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -17,6 +17,7 @@ import {
   recommendedEffort,
   resolveModel,
 } from "@/lib/models";
+import { getAssistantSettings, updateAssistantSettings } from "@/server/assistant-settings";
 import { getClaudeBin } from "@/server/claude-bin";
 import { getCockpitCacheDir, getCockpitDir } from "@/server/paths";
 import { resolveProviderModel } from "@/server/providers";
@@ -163,6 +164,7 @@ export function buildMcpConfigArg(url: string, token: string): { path: string } 
 
 export class SessionManager {
   private sessions = new Map<string, Session>();
+  private _cockpitAgentSessionPromise: Promise<string> | null = null;
   constructor() {
     // Periodically check for sessions stuck in "running" with a dead process
     setInterval(() => {
@@ -246,31 +248,34 @@ export class SessionManager {
       cockpitAgentCleanups: [],
     });
 
-    setSessionPrefs(id, { runtime: rt });
+    setSessionPrefs(id, { runtime: rt, ...(isCockpitAgent ? { cockpitAgent: true } : {}) });
 
     if (isCockpitAgent) {
-      const cleanup = this.onInit(id, async (data: InitData) => {
-        for (const server of data.mcpServers) {
-          if (server.name !== "cockpit-config" && server.status !== "disabled") {
-            try {
-              await this.mcpToggle(id, server.name, false);
-            } catch {
-              // best effort — server may not be started yet
-            }
-          }
-        }
-      });
-      if (cleanup) {
-        const session = this.sessions.get(id);
-        if (session) {
-          session.cockpitAgentCleanups.push(cleanup);
-        }
-      } else {
-        console.warn(`[cockpit-agent] onInit returned null for session ${id.slice(0, 8)}`);
-      }
+      this.registerCockpitAgentOnInit(id);
     }
 
     return info;
+  }
+
+  private registerCockpitAgentOnInit(id: string): void {
+    const session = this.sessions.get(id);
+    if (!session) return; // TypeScript narrows to Session below; push is safe
+    const cleanup = this.onInit(id, async (data: InitData) => {
+      for (const server of data.mcpServers) {
+        if (server.name !== "cockpit-config" && server.status !== "disabled") {
+          try {
+            await this.mcpToggle(id, server.name, false);
+          } catch {
+            // best effort — server may not be started yet
+          }
+        }
+      }
+    });
+    if (cleanup) {
+      session.cockpitAgentCleanups.push(cleanup); // destroySession iterates this to unsubscribe
+    } else {
+      console.warn(`[cockpit-agent] onInit returned null for session ${id.slice(0, 8)}`);
+    }
   }
 
   ensureSession(id: string, cwd: string): Session {
@@ -308,7 +313,7 @@ export class SessionManager {
         hasSpawnedBefore: true,
         cliSessionId: cliId,
         previousCliSessionIds: prevIds,
-        bypassAllPermissions: prefs?.bypassAllPermissions ?? defaults.bypassAllPermissions,
+        bypassAllPermissions: (prefs?.cockpitAgent ? false : prefs?.bypassAllPermissions) ?? defaults.bypassAllPermissions,
         planMode: prefs?.planMode ?? false,
         pendingPlanReminder: prefs?.planMode ?? false,
         needsRespawnForPermissions: false,
@@ -339,12 +344,85 @@ export class SessionManager {
         todoWatcher: null,
         attachmentPaths: [],
         totalTokens: { input: 0, output: 0, cacheCreate: 0, cacheRead: 0 },
-        cockpitAgent: false,
+        cockpitAgent: prefs?.cockpitAgent ?? false,
         cockpitAgentCleanups: [],
       };
       this.sessions.set(id, session);
+      if (prefs?.cockpitAgent) {
+        this.registerCockpitAgentOnInit(id);
+      }
     }
     return session!;
+  }
+
+  async getOrCreateCockpitAgentSession(): Promise<string> {
+    // Fast path: the session is already live in memory (the common case once the
+    // modal has been opened this server lifetime). Returns synchronously.
+    const stored = getAssistantSettings().sessionId;
+    if (stored && this.sessions.has(stored)) return stored;
+
+    // Slow path: restore-from-disk or create-new. There is no `await` between the
+    // null-check and the assignment below, so the first caller sets the promise
+    // before any other caller can run; every concurrent first-open then awaits
+    // that same single execution. The finally clears it for the next miss.
+    if (!this._cockpitAgentSessionPromise) {
+      this._cockpitAgentSessionPromise = this._resolveOrCreateCockpitAgentSession().finally(() => {
+        this._cockpitAgentSessionPromise = null;
+      });
+    }
+    return this._cockpitAgentSessionPromise;
+  }
+
+  private async _resolveOrCreateCockpitAgentSession(): Promise<string> {
+    const settings = getAssistantSettings();
+    const stored = settings.sessionId;
+    if (stored) {
+      if (this.sessions.has(stored)) return stored; // restored by an earlier caller
+      const prefs = getSessionPrefs(stored);
+      // Only restore a stored id that is genuinely a cockpit agent session. A
+      // pointer to a regular session (e.g. a hand-edited assistant.json) must not
+      // be rehydrated here — it would lack the MCP-disable/permission restrictions.
+      if (prefs?.cockpitAgent) {
+        const cwd = (await findSessionCwd(prefs.cliSessionId || stored)) ?? (await findSessionCwd(stored));
+        if (cwd) {
+          // ensureSession rebuilds in-memory state and (Step 5) registers the MCP-disable
+          // onInit listener. Model/thinking are restored from session-prefs — which the
+          // in-modal selector and the settings-page write-through both keep current —
+          // so no re-apply is needed here.
+          this.ensureSession(stored, cwd);
+          return stored;
+        }
+      }
+    }
+    // No stored id, or its transcript is gone — create a fresh session seeded from
+    // assistant.json. createSession is synchronous (this.sessions.set before return).
+    const info = this.createSession(getCockpitDir(), undefined, {
+      cockpitAgent: true,
+      runtime: settings.runtime,
+    });
+    if (settings.model) this.setModel(info.id, settings.model, settings.contextSize);
+    if (settings.thinkingLevel) this.setThinkingLevel(info.id, settings.thinkingLevel);
+    updateAssistantSettings({ sessionId: info.id });
+    return info.id;
+  }
+
+  async applyCockpitAgentSettings(update: { model?: string; thinkingLevel?: ThinkingLevel; contextSize?: ContextSize }): Promise<void> {
+    const stored = getAssistantSettings().sessionId;
+    if (!stored) return; // no session yet — assistant.json seeds the next create
+    if (!this.sessions.has(stored)) {
+      // Bring a dormant (on-disk) session into memory so the setters persist to its
+      // session-prefs. Do NOT create one if no transcript exists — a settings tweak
+      // must not spawn a session from nothing; the next create seeds from assistant.json.
+      const prefs = getSessionPrefs(stored);
+      const cwd = (await findSessionCwd(prefs?.cliSessionId || stored)) ?? (await findSessionCwd(stored));
+      if (!cwd) return;
+      this.ensureSession(stored, cwd);
+    }
+    // setModel couples model+contextSize; a context-size-only change reuses the current model.
+    if (update.model || update.contextSize) {
+      this.setModel(stored, update.model ?? this.getModel(stored), update.contextSize);
+    }
+    if (update.thinkingLevel) this.setThinkingLevel(stored, update.thinkingLevel);
   }
 
   async getSession(id: string): Promise<{

--- a/src/server/session-prefs.ts
+++ b/src/server/session-prefs.ts
@@ -26,6 +26,7 @@ export interface SessionPrefs {
   openTabs?: PersistedTab[];
   activeTabId?: string;
   runtime?: SessionRuntime;
+  cockpitAgent?: boolean;
 }
 
 function prefsDir(): string {

--- a/tests/assistant-session-route.test.ts
+++ b/tests/assistant-session-route.test.ts
@@ -1,0 +1,155 @@
+import { EventEmitter } from "node:events";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({ manager: null as any }));
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => {
+    const emitter = new EventEmitter();
+    const stdin = new (require("node:stream").PassThrough)();
+    return Object.assign(emitter, {
+      pid: 99999,
+      stdin,
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      kill: vi.fn(),
+    });
+  }),
+}));
+
+vi.mock("@/server/auth", () => ({ validateSession: (t: string) => t === "valid" }));
+
+vi.mock("@/server/paths", () => ({
+  getCockpitDir: () => "/tmp/cockpit-config",
+  getCockpitCacheDir: () => "/tmp/cockpit-cache",
+}));
+
+vi.mock("@/server/debug-logger", () => ({
+  debugLog: vi.fn(),
+  logRawLine: vi.fn(),
+  logDiag: vi.fn(),
+  logParsedEvent: vi.fn(),
+  logStatus: vi.fn(),
+  logServerMessage: vi.fn(),
+  logClientMessage: vi.fn(),
+  isDebugEnabled: vi.fn(() => false),
+}));
+
+vi.mock("@/server/transcript", () => ({
+  loadTranscript: () => Promise.resolve({ messages: [], byteOffset: 0, totalSize: 0, lastUsage: null }),
+  findSessionCwd: vi.fn(() => Promise.resolve(null)),
+  findTranscriptFile: vi.fn(() => Promise.resolve(null)),
+  getTranscriptPath: () => "/tmp/fake.jsonl",
+  loadPromptHistory: () => Promise.resolve([]),
+  transcriptExists: () => false,
+  loadMoreMessages: () => Promise.resolve({ messages: [], newByteOffset: 0 }),
+}));
+
+vi.mock("@/server/session-prefs", () => ({
+  getSessionPrefs: vi.fn(() => undefined),
+  setSessionPrefs: vi.fn(),
+  findChainForCliSession: vi.fn(() => null),
+  deleteSessionPrefs: vi.fn(),
+}));
+
+vi.mock("@/server/assistant-settings", () => ({
+  getAssistantSettings: vi.fn(() => ({ model: "sonnet", thinkingLevel: "high" })),
+  updateAssistantSettings: vi.fn((p) => ({ model: "sonnet", thinkingLevel: "high", ...p })),
+}));
+
+vi.mock("@/server/defaults", () => ({
+  getDefaults: () => ({
+    thinkingLevel: "high",
+    bypassAllPermissions: false,
+    diffStyle: "split",
+    dismissKeyboardOnSend: true,
+    thinkingExpanded: false,
+    modelSlots: { main: "sonnet" },
+  }),
+}));
+
+vi.mock("@/server/pty-runtime", () => {
+  class MockPtyRuntime {
+    isAlive = true;
+    pid = 12345;
+    start = vi.fn().mockResolvedValue(undefined);
+    kill = vi.fn().mockResolvedValue(undefined);
+    sendText = vi.fn().mockResolvedValue(undefined);
+    interrupt = vi.fn();
+    notifyPermissionDecision = vi.fn();
+  }
+  return { PtyRuntime: MockPtyRuntime };
+});
+
+vi.mock("@/server/transcript-watcher", () => {
+  class MockTranscriptWatcher {
+    start = vi.fn();
+    stop = vi.fn();
+  }
+  return { TranscriptWatcher: MockTranscriptWatcher };
+});
+
+vi.mock("@/server/singleton", () => ({
+  getSessionManager: () => h.manager,
+  getHookRouter: () => ({ register: vi.fn(), unregister: vi.fn() }),
+  getCockpitMcp: vi.fn(),
+}));
+
+import { GET } from "@/app/api/assistant-session/route";
+import { getAssistantSettings, updateAssistantSettings } from "@/server/assistant-settings";
+import { SessionManager } from "@/server/session-manager";
+import { getSessionPrefs } from "@/server/session-prefs";
+import { findSessionCwd } from "@/server/transcript";
+
+const mockGetSettings = vi.mocked(getAssistantSettings);
+const mockUpdateSettings = vi.mocked(updateAssistantSettings);
+const mockGetPrefs = vi.mocked(getSessionPrefs);
+const mockFindCwd = vi.mocked(findSessionCwd);
+
+function authedReq(): NextRequest {
+  return new NextRequest("http://localhost/api/assistant-session", {
+    headers: { cookie: "cockpit_session=valid" },
+  });
+}
+
+describe("GET /api/assistant-session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high" });
+    mockUpdateSettings.mockImplementation((p) => ({ model: "sonnet", thinkingLevel: "high", ...p }));
+    mockGetPrefs.mockReturnValue(undefined);
+    mockFindCwd.mockResolvedValue(null);
+    h.manager = new SessionManager();
+  });
+
+  it("returns a sessionId and the cockpit cwd when authed", async () => {
+    const res = await GET(authedReq());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.sessionId).toBeTruthy();
+    expect(body.cwd).toBe("/tmp/cockpit-config");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await GET(new NextRequest("http://localhost/api/assistant-session"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the same id across a simulated server restart", async () => {
+    // First open: create + persist sessionId.
+    const first = await (await GET(authedReq())).json();
+    const id = first.sessionId;
+
+    // Simulate restart: the session is gone from memory but its transcript and
+    // stored id survive on disk.
+    (h.manager as any).sessions.delete(id);
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: id });
+    mockGetPrefs.mockReturnValue({ cockpitAgent: true, cliSessionId: id });
+    mockFindCwd.mockResolvedValue("/tmp/cockpit-config");
+
+    const second = await (await GET(authedReq())).json();
+    expect(second.sessionId).toBe(id);
+    expect((h.manager as any).sessions.has(id)).toBe(true);
+  });
+});

--- a/tests/assistant-settings-route.test.ts
+++ b/tests/assistant-settings-route.test.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({ applyCockpitAgentSettings: vi.fn() }));
+
+vi.mock("@/server/auth", () => ({ validateSession: (t: string) => t === "valid" }));
+
+vi.mock("@/server/assistant-settings", () => ({
+  getAssistantSettings: vi.fn(() => ({ model: "sonnet", thinkingLevel: "high" })),
+  updateAssistantSettings: vi.fn((p) => ({ model: "sonnet", thinkingLevel: "high", ...p })),
+}));
+
+vi.mock("@/server/singleton", () => ({
+  getSessionManager: () => ({ applyCockpitAgentSettings: h.applyCockpitAgentSettings }),
+}));
+
+import { PATCH } from "@/app/api/assistant-settings/route";
+import { updateAssistantSettings } from "@/server/assistant-settings";
+
+const mockUpdate = vi.mocked(updateAssistantSettings);
+
+function makeReq(body: unknown, authed = true): NextRequest {
+  return new NextRequest("http://localhost/api/assistant-settings", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers: authed ? { cookie: "cockpit_session=valid", "content-type": "application/json" } : { "content-type": "application/json" },
+  });
+}
+
+describe("PATCH /api/assistant-settings write-through", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.applyCockpitAgentSettings.mockResolvedValue(undefined);
+  });
+
+  it("writes the change through to the cockpit session", async () => {
+    const res = await PATCH(makeReq({ model: "opus" }));
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith({ model: "opus" });
+    expect(h.applyCockpitAgentSettings).toHaveBeenCalledWith(expect.objectContaining({ model: "opus" }));
+  });
+
+  it("does not apply an empty-string model through the write-through", async () => {
+    await PATCH(makeReq({ model: "" }));
+    expect(h.applyCockpitAgentSettings).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
+  });
+
+  it("strips a client-supplied sessionId so it cannot overwrite the stored pointer", async () => {
+    await PATCH(makeReq({ model: "opus", sessionId: "attacker-session" }));
+    expect(mockUpdate).toHaveBeenCalledWith({ model: "opus" });
+    expect(mockUpdate.mock.calls[0][0]).not.toHaveProperty("sessionId");
+  });
+
+  it("returns 401 and skips the write-through when unauthenticated", async () => {
+    const res = await PATCH(makeReq({ model: "opus" }, false));
+    expect(res.status).toBe(401);
+    expect(h.applyCockpitAgentSettings).not.toHaveBeenCalled();
+  });
+});

--- a/tests/session-manager-cockpit-agent.test.ts
+++ b/tests/session-manager-cockpit-agent.test.ts
@@ -1,0 +1,249 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => {
+    const emitter = new EventEmitter();
+    const stdin = new (require("node:stream").PassThrough)();
+    return Object.assign(emitter, {
+      pid: 99999,
+      stdin,
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      kill: vi.fn(),
+    });
+  }),
+}));
+
+vi.mock("@/server/debug-logger", () => ({
+  debugLog: vi.fn(),
+  logRawLine: vi.fn(),
+  logDiag: vi.fn(),
+  logParsedEvent: vi.fn(),
+  logStatus: vi.fn(),
+  logServerMessage: vi.fn(),
+  logClientMessage: vi.fn(),
+  isDebugEnabled: vi.fn(() => false),
+}));
+
+vi.mock("@/server/transcript", () => ({
+  loadTranscript: () => Promise.resolve({ messages: [], byteOffset: 0, totalSize: 0, lastUsage: null }),
+  findSessionCwd: vi.fn(() => Promise.resolve(null)),
+  findTranscriptFile: vi.fn(() => Promise.resolve(null)),
+  getTranscriptPath: () => "/tmp/fake.jsonl",
+  loadPromptHistory: () => Promise.resolve([]),
+  transcriptExists: () => false,
+  loadMoreMessages: () => Promise.resolve({ messages: [], newByteOffset: 0 }),
+}));
+
+vi.mock("@/server/session-prefs", () => ({
+  getSessionPrefs: vi.fn(() => undefined),
+  setSessionPrefs: vi.fn(),
+  findChainForCliSession: vi.fn(() => null),
+  deleteSessionPrefs: vi.fn(),
+}));
+
+vi.mock("@/server/assistant-settings", () => ({
+  getAssistantSettings: vi.fn(() => ({ model: "sonnet", thinkingLevel: "high" })),
+  updateAssistantSettings: vi.fn((p) => ({ model: "sonnet", thinkingLevel: "high", ...p })),
+}));
+
+vi.mock("@/server/defaults", () => ({
+  getDefaults: () => ({
+    thinkingLevel: "high",
+    bypassAllPermissions: false,
+    diffStyle: "split",
+    dismissKeyboardOnSend: true,
+    thinkingExpanded: false,
+    modelSlots: { main: "sonnet" },
+  }),
+}));
+
+vi.mock("@/server/pty-runtime", () => {
+  class MockPtyRuntime {
+    isAlive = true;
+    pid = 12345;
+    start = vi.fn().mockResolvedValue(undefined);
+    kill = vi.fn().mockResolvedValue(undefined);
+    sendText = vi.fn().mockResolvedValue(undefined);
+    interrupt = vi.fn();
+    notifyPermissionDecision = vi.fn();
+  }
+  return { PtyRuntime: MockPtyRuntime };
+});
+
+vi.mock("@/server/singleton", () => ({
+  getHookRouter: vi.fn(() => ({ register: vi.fn(), unregister: vi.fn() })),
+  getSessionManager: vi.fn(),
+}));
+
+vi.mock("@/server/transcript-watcher", () => {
+  class MockTranscriptWatcher {
+    start = vi.fn();
+    stop = vi.fn();
+  }
+  return { TranscriptWatcher: MockTranscriptWatcher };
+});
+
+vi.mock("@/server/paths", () => ({
+  getCockpitDir: () => "/tmp/cockpit-config",
+  getCockpitCacheDir: () => "/tmp/cockpit-cache",
+}));
+
+import { getAssistantSettings, updateAssistantSettings } from "@/server/assistant-settings";
+import { SessionManager } from "@/server/session-manager";
+import { getSessionPrefs, setSessionPrefs } from "@/server/session-prefs";
+import { findSessionCwd } from "@/server/transcript";
+
+const mockGetSettings = vi.mocked(getAssistantSettings);
+const mockUpdateSettings = vi.mocked(updateAssistantSettings);
+const mockGetPrefs = vi.mocked(getSessionPrefs);
+const mockSetPrefs = vi.mocked(setSessionPrefs);
+const mockFindCwd = vi.mocked(findSessionCwd);
+
+describe("SessionManager cockpit agent session", () => {
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high" });
+    mockUpdateSettings.mockImplementation((p) => ({ model: "sonnet", thinkingLevel: "high", ...p }));
+    mockGetPrefs.mockReturnValue(undefined);
+    mockFindCwd.mockResolvedValue(null);
+    manager = new SessionManager();
+  });
+
+  it("creates a new session when no sessionId is stored", async () => {
+    const createSpy = vi.spyOn(manager, "createSession");
+    const id = await manager.getOrCreateCockpitAgentSession();
+
+    expect(id).toBeTruthy();
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    // prefs write persists the cockpitAgent flag
+    expect(mockSetPrefs).toHaveBeenCalledWith(id, expect.objectContaining({ cockpitAgent: true }));
+    // the new session id is persisted to assistant.json
+    expect(mockUpdateSettings).toHaveBeenCalledWith({ sessionId: id });
+    expect((manager as any).sessions.get(id).cockpitAgent).toBe(true);
+  });
+
+  it("returns the stored id without creating when the session is already in memory", async () => {
+    const created = manager.createSession("/tmp/cockpit-config", undefined, { cockpitAgent: true });
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: created.id });
+
+    const createSpy = vi.spyOn(manager, "createSession");
+    const id = await manager.getOrCreateCockpitAgentSession();
+
+    expect(id).toBe(created.id);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("restores a stored session from disk after a server restart", async () => {
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: "S" });
+    mockGetPrefs.mockReturnValue({ cockpitAgent: true, cliSessionId: "S" });
+    mockFindCwd.mockResolvedValue("/tmp/cockpit-config");
+
+    const createSpy = vi.spyOn(manager, "createSession");
+    const id = await manager.getOrCreateCockpitAgentSession();
+
+    expect(id).toBe("S");
+    expect(createSpy).not.toHaveBeenCalled();
+    const session = (manager as any).sessions.get("S");
+    expect(session.cockpitAgent).toBe(true);
+    expect(session.cockpitAgentCleanups.length).toBeGreaterThan(0);
+  });
+
+  it("creates a fresh session when the stored id has no transcript", async () => {
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: "gone" });
+    mockGetPrefs.mockReturnValue({ cockpitAgent: true, cliSessionId: "gone" });
+    mockFindCwd.mockResolvedValue(null);
+
+    const createSpy = vi.spyOn(manager, "createSession");
+    const id = await manager.getOrCreateCockpitAgentSession();
+
+    expect(id).not.toBe("gone");
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSettings).toHaveBeenCalledWith({ sessionId: id });
+  });
+
+  it("restores previousCliSessionIds across a /clear round-trip", async () => {
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: "S" });
+    mockGetPrefs.mockReturnValue({
+      cockpitAgent: true,
+      cliSessionId: "new-cli",
+      previousCliSessionIds: ["old-cli"],
+    });
+    mockFindCwd.mockResolvedValue("/tmp/cockpit-config");
+
+    const id = await manager.getOrCreateCockpitAgentSession();
+    expect(id).toBe("S");
+    expect((manager as any).sessions.get("S").previousCliSessionIds).toContain("old-cli");
+  });
+
+  it("funnels concurrent first-opens onto a single create", async () => {
+    const createSpy = vi.spyOn(manager, "createSession");
+    const [a, b] = await Promise.all([manager.getOrCreateCockpitAgentSession(), manager.getOrCreateCockpitAgentSession()]);
+    expect(a).toBe(b);
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("restore does not clobber an in-modal model choice with stale assistant.json", async () => {
+    // assistant.json is stale (sonnet) but session-prefs holds the newer in-modal choice (opus)
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: "S" });
+    mockGetPrefs.mockReturnValue({ cockpitAgent: true, modelSlots: { main: "opus" }, cliSessionId: "S" });
+    mockFindCwd.mockResolvedValue("/tmp/cockpit-config");
+
+    await manager.getOrCreateCockpitAgentSession();
+    expect((manager as any).sessions.get("S").info.model).toBe("opus");
+  });
+
+  it("writes a settings change through to a live session", async () => {
+    const created = manager.createSession("/tmp/cockpit-config", undefined, { cockpitAgent: true });
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: created.id });
+
+    await manager.applyCockpitAgentSettings({ model: "opus" });
+
+    expect((manager as any).sessions.get(created.id).info.model).toBe("opus");
+    expect(mockSetPrefs).toHaveBeenCalledWith(created.id, expect.objectContaining({ model: "opus" }));
+  });
+
+  it("brings a dormant session into memory to apply a settings change", async () => {
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: "S" });
+    mockGetPrefs.mockReturnValue({ cockpitAgent: true, cliSessionId: "S" });
+    mockFindCwd.mockResolvedValue("/tmp/cockpit-config");
+
+    await manager.applyCockpitAgentSettings({ thinkingLevel: "low" });
+
+    expect((manager as any).sessions.has("S")).toBe(true);
+    expect((manager as any).sessions.get("S").thinkingLevel).toBe("low");
+  });
+
+  it("no-ops the write-through when no session is stored", async () => {
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high" });
+    const createSpy = vi.spyOn(manager, "createSession");
+
+    await expect(manager.applyCockpitAgentSettings({ model: "opus" })).resolves.toBeUndefined();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("no-ops the write-through when the stored transcript is gone", async () => {
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: "S" });
+    mockGetPrefs.mockReturnValue({ cockpitAgent: true, cliSessionId: "S" });
+    mockFindCwd.mockResolvedValue(null);
+    const createSpy = vi.spyOn(manager, "createSession");
+
+    await manager.applyCockpitAgentSettings({ model: "opus" });
+
+    expect((manager as any).sessions.has("S")).toBe(false);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("applies a contextSize-only change using the current model", async () => {
+    const created = manager.createSession("/tmp/cockpit-config", undefined, { cockpitAgent: true });
+    mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: created.id });
+    const setModelSpy = vi.spyOn(manager, "setModel");
+
+    await manager.applyCockpitAgentSettings({ contextSize: "1m" });
+
+    expect(setModelSpy).toHaveBeenCalledWith(created.id, manager.getModel(created.id), "1m");
+  });
+});

--- a/tests/sessions-route-filter.test.ts
+++ b/tests/sessions-route-filter.test.ts
@@ -1,0 +1,184 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionInfo } from "@/types";
+
+const COCKPIT_DIR = "/tmp/cockpit-config";
+
+const h = vi.hoisted(() => ({
+  scanAllSessions: vi.fn(),
+  scanSessionsForCwd: vi.fn(),
+  listActiveSessions: vi.fn((): unknown[] => []),
+  listKnownSessions: vi.fn((): unknown[] => []),
+}));
+
+vi.mock("@/server/auth", () => ({ validateSession: (t: string) => t === "valid" }));
+vi.mock("@/server/debug-logger", () => ({ debugLog: vi.fn() }));
+vi.mock("@/server/paths", () => ({ getCockpitDir: () => COCKPIT_DIR }));
+vi.mock("@/server/transcript", () => ({
+  scanAllSessions: h.scanAllSessions,
+  scanSessionsForCwd: h.scanSessionsForCwd,
+}));
+vi.mock("@/server/singleton", () => ({
+  getSessionManager: () => ({
+    listActiveSessions: h.listActiveSessions,
+    listKnownSessions: h.listKnownSessions,
+  }),
+}));
+
+import { GET as GET_GROUP } from "@/app/api/sessions/group/route";
+import { GET as GET_LIST } from "@/app/api/sessions/route";
+
+function session(id: string, cwd: string, name: string): SessionInfo {
+  return {
+    id,
+    name,
+    cwd,
+    createdAt: 1,
+    lastActiveAt: 1,
+    status: "idle",
+    pendingRequestCount: 0,
+  } as SessionInfo;
+}
+
+function authedReq(url: string): NextRequest {
+  return new NextRequest(url, { headers: { cookie: "cockpit_session=valid" } });
+}
+
+describe("GET /api/sessions cockpit-agent exclusion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.listActiveSessions.mockReturnValue([]);
+    h.listKnownSessions.mockReturnValue([]);
+  });
+
+  it("excludes the cockpit dir group whether it is on disk or in memory only", async () => {
+    h.scanAllSessions.mockResolvedValue([
+      {
+        cwd: COCKPIT_DIR,
+        dirName: "cockpit-config",
+        sessions: [session("disk-1", COCKPIT_DIR, "Cockpit Assistant")],
+        totalSessionCount: 1,
+      },
+      { cwd: "/home/dev/proj", dirName: "proj", sessions: [session("proj-1", "/home/dev/proj", "proj")], totalSessionCount: 1 },
+    ]);
+    // an in-memory cockpit session with no transcript yet
+    h.listKnownSessions.mockReturnValue([session("mem-1", COCKPIT_DIR, "Cockpit Assistant")]);
+
+    const res = await GET_LIST(authedReq("http://localhost/api/sessions"));
+    const body = await res.json();
+
+    const cwds = body.groups.map((g: { cwd: string }) => g.cwd);
+    expect(cwds).not.toContain(COCKPIT_DIR);
+    expect(cwds).toContain("/home/dev/proj");
+    const allIds = body.groups.flatMap((g: { sessions: SessionInfo[] }) => g.sessions.map((s) => s.id));
+    expect(allIds).not.toContain("disk-1");
+    expect(allIds).not.toContain("mem-1");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await GET_LIST(new NextRequest("http://localhost/api/sessions"));
+    expect(res.status).toBe(401);
+  });
+
+  it("merges live status/name, drops job sessions, and adds in-memory-only groups", async () => {
+    const running = session("act-1", "/home/dev/proj", "on-disk-name");
+    const job = session("job-1", "/home/dev/proj", "[job] nightly");
+    h.scanAllSessions.mockResolvedValue([{ cwd: "/home/dev/proj", dirName: "proj", sessions: [running, job], totalSessionCount: 2 }]);
+    h.listActiveSessions.mockReturnValue([{ id: "act-1", status: "running", pendingRequestCount: 4, name: "x", cwd: "/home/dev/proj" }]);
+    h.listKnownSessions.mockReturnValue([
+      { ...session("act-1", "/home/dev/proj", "Renamed"), status: "running" },
+      // in-memory session in a cwd with no transcript group yet -> creates a new group
+      session("mem-new", "/home/dev/other", "Fresh"),
+    ]);
+
+    const res = await GET_LIST(authedReq("http://localhost/api/sessions"));
+    const body = await res.json();
+
+    const proj = body.groups.find((g: { cwd: string }) => g.cwd === "/home/dev/proj");
+    const merged = proj.sessions.find((s: SessionInfo) => s.id === "act-1");
+    expect(merged.status).toBe("running");
+    expect(merged.pendingRequestCount).toBe(4);
+    expect(merged.name).toBe("Renamed");
+    // the job session is filtered out
+    expect(proj.sessions.map((s: SessionInfo) => s.id)).not.toContain("job-1");
+    // the in-memory-only session forms its own group
+    expect(body.groups.map((g: { cwd: string }) => g.cwd)).toContain("/home/dev/other");
+  });
+
+  it("returns only review sessions for type=reviews", async () => {
+    h.scanAllSessions.mockResolvedValue([
+      {
+        cwd: "/home/dev/.cockpit/reviews/r1",
+        dirName: "r1",
+        sessions: [session("rev-1", "/home/dev/.cockpit/reviews/r1", "review")],
+        totalSessionCount: 1,
+      },
+      { cwd: "/home/dev/proj", dirName: "proj", sessions: [session("proj-1", "/home/dev/proj", "proj")], totalSessionCount: 1 },
+    ]);
+
+    const res = await GET_LIST(authedReq("http://localhost/api/sessions?type=reviews"));
+    const body = await res.json();
+
+    expect(body.sessions.map((s: SessionInfo) => s.id)).toEqual(["rev-1"]);
+  });
+});
+
+describe("GET /api/sessions/group cockpit-agent exclusion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.listActiveSessions.mockReturnValue([]);
+    h.listKnownSessions.mockReturnValue([]);
+  });
+
+  it("returns no sessions for the cockpit dir regardless of what is on disk", async () => {
+    h.scanSessionsForCwd.mockResolvedValue([session("disk-1", COCKPIT_DIR, "Cockpit Assistant")]);
+
+    const res = await GET_GROUP(authedReq(`http://localhost/api/sessions/group?cwd=${encodeURIComponent(COCKPIT_DIR)}`));
+    const body = await res.json();
+
+    expect(body.sessions).toEqual([]);
+    expect(h.scanSessionsForCwd).not.toHaveBeenCalled();
+  });
+
+  it("still lists sessions for a normal cwd", async () => {
+    h.scanSessionsForCwd.mockResolvedValue([session("proj-1", "/home/dev/proj", "proj")]);
+
+    const res = await GET_GROUP(authedReq("http://localhost/api/sessions/group?cwd=/home/dev/proj"));
+    const body = await res.json();
+
+    expect(body.sessions.map((s: SessionInfo) => s.id)).toContain("proj-1");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await GET_GROUP(new NextRequest("http://localhost/api/sessions/group?cwd=/home/dev/proj"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when cwd is missing", async () => {
+    const res = await GET_GROUP(authedReq("http://localhost/api/sessions/group"));
+    expect(res.status).toBe(400);
+  });
+
+  it("merges live status/name, drops job sessions, and adds in-memory-only sessions", async () => {
+    h.scanSessionsForCwd.mockResolvedValue([
+      session("disk-1", "/home/dev/proj", "on-disk"),
+      session("job-1", "/home/dev/proj", "[job] nightly"),
+    ]);
+    h.listActiveSessions.mockReturnValue([{ id: "disk-1", status: "running", pendingRequestCount: 2, name: "x", cwd: "/home/dev/proj" }]);
+    h.listKnownSessions.mockReturnValue([
+      { ...session("disk-1", "/home/dev/proj", "Renamed"), status: "running" },
+      session("mem-1", "/home/dev/proj", "In-memory"),
+    ]);
+
+    const res = await GET_GROUP(authedReq("http://localhost/api/sessions/group?cwd=/home/dev/proj"));
+    const body = await res.json();
+
+    const ids = body.sessions.map((s: SessionInfo) => s.id);
+    expect(ids).toContain("disk-1");
+    expect(ids).toContain("mem-1");
+    expect(ids).not.toContain("job-1");
+    const merged = body.sessions.find((s: SessionInfo) => s.id === "disk-1");
+    expect(merged.status).toBe("running");
+    expect(merged.name).toBe("Renamed");
+  });
+});


### PR DESCRIPTION
Implements ALE-616. The cockpit agent modal now reconnects to one persistent session across page refreshes and server restarts, never appears in the main sessions list, and applies Cockpit Agent settings-page model/thinking changes to the live session with persistence across restart.

## Summary
- `SessionPrefs` gains `cockpitAgent`; `AssistantSettings` gains `sessionId` (both optional, no migration).
- `createSession` persists `cockpitAgent: true` to session-prefs; the inline MCP-disable onInit block is extracted to `registerCockpitAgentOnInit`.
- `ensureSession` restores the `cockpitAgent` flag, forces `bypassAllPermissions: false` for cockpit sessions, and registers the onInit listener from every callsite.
- `getOrCreateCockpitAgentSession` (single-flight via `_cockpitAgentSessionPromise`) resolves an in-memory/dormant session or creates a fresh one seeded from `assistant.json`; restore only rehydrates a pointer whose prefs are genuinely `cockpitAgent` (hardening).
- `applyCockpitAgentSettings` writes settings-page changes through to the live or dormant session via the existing `setModel`/`setThinkingLevel` (session-prefs stays the single source of truth).
- New `GET /api/assistant-session`; the modal init switches to a single call to it.
- `PATCH /api/assistant-settings` writes through to the cockpit session (body sanitized to the settings fields so a client cannot overwrite the server-managed `sessionId`); the settings page PATCHes only the changed field.
- `GET /api/sessions` and `GET /api/sessions/group` exclude the cockpit dir.

## Acceptance criteria
- [x] Modal reconnects to the same session after a page refresh
- [x] Modal reconnects + loads transcript after a server restart
- [x] /clear + refresh continues in the same session (previousCliSessionIds preserved)
- [x] Cockpit agent session never appears in the main sessions list (pre-open, open, closed)
- [x] GET /api/sessions/group with the cockpit cwd returns no sessions
- [x] GET /api/assistant-session is idempotent within a server lifetime
- [x] GET /api/assistant-session with no stored session creates and returns a new ID
- [x] Simulated restart returns the original session ID
- [x] Restored session has cockpitAgent true with its onInit listener registered
- [x] Settings-page model/thinking change applies to the live (or dormant) session and survives restart
- [x] In-modal model change is preserved after a restart (no clobber)
- [x] A settings change does not create a session when none exists
- [x] All new unit tests pass with npx vitest run

## Deviations from plan
- Step 8 originally passed the raw PATCH body to `updateAssistantSettings`. Since this PR adds `sessionId` to `AssistantSettings`, the raw passthrough became a vector to overwrite the server-managed session pointer (code-review Medium 1). The PATCH now sanitizes the body to `{model, thinkingLevel, runtime, contextSize}` before persisting. Behaviour for the settings page is unchanged.
- Added a guard in `_resolveOrCreateCockpitAgentSession` so a stored pointer is only restored when its prefs are `cockpitAgent` (code-review Low 3); a non-cockpit pointer falls through to a fresh create. Pairs with the above to close the privilege-bypass class.

## Review
Completeness: COMPLETE (13/13 criteria). Code review: PASS round 1/4 (no Critical/High; Medium 1 + Low 3 fixed, Medium 2 out of scope). UI review: PASS (8 screenshots attached to the issue). Verified: typecheck, build, lint, full vitest suite (1507 passing, 1 skipped), coverage 80.11% branch.

Refs ALE-616