### PR TITLE
Disable shell-cache service worker in development

### DIFF
--- a/.claude/skills/browser-test/SKILL.md
+++ b/.claude/skills/browser-test/SKILL.md
@@ -58,9 +58,15 @@ Then `browser_navigate` to `http://localhost:3010/login` and submit the setup fo
 
 You land on `/`, authenticated.
 
-## 3. Clear the service worker — the one that wastes the most time
+## 3. The service worker — now auto-handled in dev (was the #1 time sink)
 
-cockpit registers a service worker that caches the app shell (cache name like `cockpit-shell-v2`). It serves stale JS **across server restarts and `.next` deletes**. Until you clear it, you are looking at OLD code no matter what you change. After navigating, run this, then navigate again:
+cockpit's PWA service worker (`sw.js`, cache `cockpit-shell-v2`) is **cache-first for `/_next/static`**. That is correct in production (content-hashed URLs) but poison in dev: turbopack dev chunk URLs are stable while their contents change across edits and server restarts, so the SW serves a stale chunk against a fresh shell. As of the layout.tsx fix, **the SW is no longer registered in development**, and a dev page actively unregisters any leftover SW and clears its caches on load. So a fresh spare port is clean, and a port previously poisoned by an old SW self-heals.
+
+**The symptom this caused** (worth recognising — it cost hours): a **blank page** where every `/_next/static/*.js` chunk loads `200`, React never mounts (`document.body.innerText` empty, only a `<div hidden><!--$--><!--/$--></div>` placeholder), and the console shows **only** HMR-websocket failures. That is a stale SW serving mismatched cached chunks, not a code bug.
+
+Why it bit the MCP but not the ui-reviewer: SW scope is **per origin including port**. The ui-reviewer uses a fresh spare port (and a fresh browser profile) each run, so its origin never has a prior SW. The MCP reuses a small set of ports/profile, so a port that hosted an earlier server still carries that origin's stale SW. Two consequences:
+- **Prefer a unique, not-recently-used port** per run (and vary it if you hit a blank page).
+- If you do hit the blank page on a reused port, just **reload once** — the dev cleanup script already unregistered the SW on the first load; the reload lands clean. Belt-and-braces manual clear (rarely needed now):
 
 ```js
 async () => {
@@ -69,7 +75,7 @@ async () => {
 }
 ```
 
-Confirm you're on current code before trusting anything: read a class or text you just changed off the live DOM via `browser_evaluate` and compare to source.
+After it, navigate again. Confirm you're on current code: read a class or text you just changed off the live DOM via `browser_evaluate` and compare to source. A quick tell that no SW is interfering: `navigator.serviceWorker.controller === null`.
 
 ## 4. Drive the UI
 
@@ -92,9 +98,9 @@ Skip either and you keep seeing stale code.
 ## 6. Teardown
 
 ```bash
-kill $(lsof -ti:3010) 2>/dev/null; pkill -f "tsx server.ts" 2>/dev/null
+kill $(lsof -ti:3010) 2>/dev/null || true   # kill by PORT only
 rm -rf /tmp/cockpit-verify /tmp/cockpit-verify.log
 rm -f /home/dev/repos/cockpit/*.png   # screenshots browser_take_screenshot saved into the repo root
 ```
 
-Leave `.next` (gitignored). The live instance on 3001 is untouched throughout.
+Kill by **port**, not `pkill -f "tsx server.ts"` — that pattern matches every cockpit dev server (sibling worktrees, the implement-issue review server, the ui-reviewer's server) and will take them all down. Leave `.next` (gitignored). The live instance on 3001 is untouched throughout.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,6 +31,19 @@ export const viewport: Viewport = {
   ],
 };
 
+const THEME_INIT = `(function(){try{var t=localStorage.getItem("cockpit-theme");var d=t==="dark"||(t!=="light"&&matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")}catch(e){}})();`;
+
+// The shell-cache service worker (sw.js) is cache-first for /_next/static, which is
+// correct in production (content-hashed URLs) but poisons development: dev chunk URLs
+// are stable while their contents change across edits and server restarts, so a stale
+// chunk gets served against a fresh shell and the page fails to hydrate (blank screen).
+// Register it only in production; in dev, actively unregister any leftover SW and clear
+// its caches so a previously-poisoned origin self-heals on the next load.
+const SW_SCRIPT =
+  process.env.NODE_ENV === "production"
+    ? `if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}`
+    : `if("serviceWorker"in navigator){navigator.serviceWorker.getRegistrations().then(function(rs){rs.forEach(function(r){r.unregister()})});if(window.caches){caches.keys().then(function(ks){ks.forEach(function(k){caches.delete(k)})})}}`;
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="h-full overflow-hidden" suppressHydrationWarning>
@@ -38,7 +51,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {children}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem("cockpit-theme");var d=t==="dark"||(t!=="light"&&matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")}catch(e){}})();if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}`,
+            __html: THEME_INIT + SW_SCRIPT,
           }}
         />
       </body>


### PR DESCRIPTION
## Problem

The PWA service worker (`public/sw.js`, cache `cockpit-shell-v2`) is **cache-first for `/_next/static`**. That is correct in production (content-hashed chunk URLs) but poisons development: turbopack dev chunk URLs are *stable* while their contents change across edits and server restarts, so the SW serves a stale chunk against a freshly-compiled shell. The result is a **blank page** — every `/_next/static/*.js` loads `200`, but React never mounts and the console shows only HMR-websocket failures.

Because a service worker's scope is **per origin including port**, this hit any workflow that reuses a port — notably the Playwright MCP `browser-test` flow — while sparing the `ui-reviewer`, which spins up a fresh spare port (and fresh browser profile) each run. That asymmetry is why "it works for the ui-reviewer but not the MCP."

The HMR-websocket errors are a red herring: `server.ts` doesn't forward Next's dev HMR upgrade, but the app hydrates fine without it (confirmed — a clean origin with the same rejected HMR ws renders normally). The blank page is purely the stale SW.

## Fix

`src/app/layout.tsx`:
- Register `sw.js` only when `NODE_ENV === "production"`.
- In development, actively **unregister** any leftover SW and **clear its caches** on load, so an origin previously poisoned by an old SW self-heals. The shell HTML is network-first, so the fresh document always carries this cleanup script even when a stale SW is active.

`.claude/skills/browser-test/SKILL.md`:
- Document the blank-page symptom and its real cause.
- Recommend a unique, not-recently-used port (and varying it on a blank page).
- Fix a teardown footgun: `pkill -f "tsx server.ts"` matched **every** cockpit dev server (sibling worktrees, the implement-issue review server, the ui-reviewer's server). Kill by port only.

## Verification

- **Production unchanged:** prerendered prod HTML (`next build --webpack`) emits only `serviceWorker.register("/sw.js")`; the dev-unregister branch is absent.
- **Dev self-heal, live:** loaded a previously-poisoned origin (`127.0.0.1:3011`, carrying a stale `cockpit-shell-v2`) under the fix — first load blank (stale SW still controlling), then **fully hydrated on reload** (dashboard rendered, `serviceWorker.controller === null`, 0 registrations, caches empty).
- Typecheck (app + server), lint, and `npm run build` all green.

## Out of scope

`server.ts` not forwarding the Next dev HMR websocket (so hot-reload doesn't work; the skill's edit-then-restart loop remains). It's a separate DX gap and is not what causes the blank page.