### PR TITLE
fix(session): resolve --resume from the on-disk transcript (ALE-601)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -160,10 +160,16 @@ The human verifies the feature by clicking a link, not by checking out the branc
 3. Use a throwaway, per-issue config dir so it does not collide with the live scheduler or other test servers: `/tmp/cockpit-review-<ISSUE-ID>`.
 4. Start the server **detached into its own session with `setsid`** so it survives this job ending. A plain `nohup ... &` does NOT survive: the job kills its whole process group on completion (`destroySession` → `killProcessGroup`), and the server would be in that group. `setsid` puts it in a new group.
 
+   **Strip inherited provider env vars** with `env -u`. If the agent launching this skill is itself running under a custom provider (e.g. a Deepseek-backed run), its `ANTHROPIC_BASE_URL` / `ANTHROPIC_DEFAULT_*_MODEL` / `ANTHROPIC_AUTH_TOKEN` vars are in the shell environment and the spawned cockpit server passes them straight through to every Claude CLI it spawns. The session then runs that provider's model while the UI still shows the built-in Anthropic selection (the picker says Sonnet, the CLI is really on `deepseek-v4-pro`). Unsetting them forces the review server onto real Anthropic so the human reviews against the model the UI claims.
+
    ```
    cd ../cockpit-<ISSUE-ID>
    rm -rf .next   # Next resolves the workspace root at the parent dir and can serve the MAIN repo's stale .next; clear it or the reviewer sees old code
-   NODE_ENV=development COCKPIT_CONFIG_DIR=/tmp/cockpit-review-<ISSUE-ID> PORT=<port> \
+   env -u ANTHROPIC_BASE_URL -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_API_KEY \
+       -u ANTHROPIC_MODEL -u ANTHROPIC_DEFAULT_OPUS_MODEL -u ANTHROPIC_DEFAULT_SONNET_MODEL \
+       -u ANTHROPIC_DEFAULT_HAIKU_MODEL -u ANTHROPIC_SMALL_FAST_MODEL \
+       -u CLAUDE_CODE_SUBAGENT_MODEL -u CLAUDE_CODE_EFFORT_LEVEL \
+     NODE_ENV=development COCKPIT_CONFIG_DIR=/tmp/cockpit-review-<ISSUE-ID> PORT=<port> \
      setsid nohup npx tsx server.ts > /tmp/cockpit-review-<ISSUE-ID>.log 2>&1 &
    ```
 5. Poll readiness with `curl --retry` (foreground `sleep` is blocked). Then set the password via the `/login` setup screen (see `.claude/skills/browser-test/SKILL.md` for the React-input setter), using the password from step 2.
@@ -193,6 +199,6 @@ Leave the worktree and the test server running. They are the human's review surf
 - If the change touches UI, run the ui-reviewer agent (up to 4 rounds, same as code review) so screenshots of the change are attached to the issue before the human gate. Still failing after four: carry the findings to Human Review with the screenshots attached.
 - Run the completeness-reviewer agent first (before code and UI review, up to 4 rounds) as a coverage check that every acceptance criterion has implementing code or a test; purely-visual criteria are deferred to the ui-reviewer and the human. Genuinely unmet after four: carry the gaps to Human Review as a comment.
 - If a late UI fix changes non-trivial logic (not just markup or CSS), re-run the code-reviewer on that delta so the behavioural change still gets a correctness pass.
-- Start the test server with `setsid` (not bare `nohup`) so it survives the job. Bind a free port (never 3001), use a per-issue throwaway config dir, and a freshly generated password each time.
+- Start the test server with `setsid` (not bare `nohup`) so it survives the job, and strip inherited provider env vars with `env -u` (see step 12) so a Deepseek-backed agent run does not leak its `ANTHROPIC_*` model overrides into the review server. Bind a free port (never 3001), use a per-issue throwaway config dir, and a freshly generated password each time.
 - Do NOT remove the worktree or kill the test server. The `accept-issue` skill owns that cleanup.
 - Honor Out of Scope. Match the codebase's conventions from the plan's Reference Patterns.

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -98,7 +98,6 @@ interface Session {
   process: ChildProcess | null;
   stdin: Writable | null;
   emitter: EventEmitter;
-  hasSpawnedBefore: boolean;
   cliSessionId: string;
   previousCliSessionIds: string[];
   bypassAllPermissions: boolean;
@@ -179,7 +178,6 @@ export class SessionManager {
             runtime: session.runtime,
             spawning: session.spawning ?? false,
             hasPtyRuntime: !!session.ptyRuntime,
-            hasSpawnedBefore: session.hasSpawnedBefore,
           });
           session.info.status = "idle";
           session.emitter.emit("status", id, "idle");
@@ -218,7 +216,6 @@ export class SessionManager {
       process: null,
       stdin: null,
       emitter: new EventEmitter(),
-      hasSpawnedBefore: false,
       cliSessionId: id,
       previousCliSessionIds: [],
       bypassAllPermissions: isCockpitAgent ? false : (options?.bypassPermissions ?? defaults.bypassAllPermissions),
@@ -313,7 +310,6 @@ export class SessionManager {
         process: null,
         stdin: null,
         emitter: new EventEmitter(),
-        hasSpawnedBefore: true,
         cliSessionId: cliId,
         previousCliSessionIds: prevIds,
         bypassAllPermissions: (prefs?.cockpitAgent ? false : prefs?.bypassAllPermissions) ?? defaults.bypassAllPermissions,
@@ -795,7 +791,6 @@ export class SessionManager {
     }
 
     this.killProcess(session);
-    this.recomputeResumeEligibility(session);
     session.pendingRequests.clear();
     this.notifyPendingChanged(session, sessionId);
     session.streamingSnapshot = null;
@@ -1101,7 +1096,6 @@ export class SessionManager {
     if (!session.process && !session.ptyRuntime?.isAlive) return;
     if (session.info.status === "idle") {
       this.killProcess(session);
-      this.recomputeResumeEligibility(session);
     } else {
       session.needsRespawnForPermissions = true;
     }
@@ -1114,7 +1108,6 @@ export class SessionManager {
     session.info.runtime = runtime;
     setSessionPrefs(sessionId, { runtime });
     this.killProcess(session);
-    this.recomputeResumeEligibility(session);
     this.emitInfoUpdated(session, sessionId);
     return true;
   }
@@ -1134,7 +1127,6 @@ export class SessionManager {
     // which lets the CLI natively enforce plan mode tool restrictions.
     if (session.process || session.ptyRuntime?.isAlive) {
       this.killProcess(session);
-      this.recomputeResumeEligibility(session);
       session.info.status = "idle";
       session.emitter.emit("status", sessionId, "idle");
     }
@@ -1153,7 +1145,6 @@ export class SessionManager {
     // restoring bypass capability for build mode.
     if (session.process || session.ptyRuntime?.isAlive) {
       this.killProcess(session);
-      this.recomputeResumeEligibility(session);
       session.info.status = "idle";
       session.emitter.emit("status", sessionId, "idle");
     }
@@ -1237,7 +1228,6 @@ export class SessionManager {
     } else {
       this.log(sessionId, `setModel: killing process (hasStdin=${!!session.stdin}, contextChanged=${contextChanged})`);
       this.killProcess(session);
-      this.recomputeResumeEligibility(session);
       session.queuedMessages.length = 0;
       session.queuePaused = false;
       session.info.status = "idle";
@@ -1266,7 +1256,6 @@ export class SessionManager {
       this.setModel(sessionId, modelId);
     } else {
       this.killProcess(session);
-      this.recomputeResumeEligibility(session);
       session.queuedMessages.length = 0;
       session.queuePaused = false;
       session.info.status = "idle";
@@ -1295,7 +1284,6 @@ export class SessionManager {
       session.stdin.write(JSON.stringify(request) + "\n");
     } else if (!session.stdin) {
       this.killProcess(session);
-      this.recomputeResumeEligibility(session);
       session.queuedMessages.length = 0;
       session.queuePaused = false;
       session.info.status = "idle";
@@ -1595,19 +1583,11 @@ export class SessionManager {
       session.ptyRuntime = null;
       runtime.kill().catch(() => {});
     }
+    // A kill ends any in-flight spawn, so clear the ensureProcess guard now. A
+    // deliberate kill-then-respawn (settings change, /clear, restart) must not
+    // be blocked until the dying runtime's start() promise happens to settle.
+    session.spawning = false;
     session.compacting = false;
-  }
-
-  /**
-   * Recompute whether the next spawn may --resume, after killing the CLI for a
-   * settings change. hasSpawnedBefore is set at spawn time, before the CLI
-   * persists a transcript, so a kill-then-respawn before the first turn would
-   * otherwise --resume a session the CLI never wrote (it exits at startup:
-   * "session cannot be found"). A transcript on disk is the only durable proof
-   * the session is resumable, so derive the flag from it.
-   */
-  private recomputeResumeEligibility(session: Session): void {
-    session.hasSpawnedBefore = transcriptExists(session.cliSessionId, session.info.cwd);
   }
 
   private emitSystem(session: Session, sessionId: string, text: string): void {
@@ -1857,7 +1837,6 @@ export class SessionManager {
         // generate a new CLI session ID to get a fresh context.
         session.previousCliSessionIds.push(session.cliSessionId);
         session.cliSessionId = uuidv4();
-        session.hasSpawnedBefore = false;
         session.queuedMessages.length = 0;
         session.queuePaused = false;
         session.todoItems = [];
@@ -1879,7 +1858,6 @@ export class SessionManager {
         }
         this.log(sessionId, `/model command: args="${args}", was=${session.info.model}`);
         this.killProcess(session);
-        this.recomputeResumeEligibility(session);
         session.info.model = args;
         session.info.status = "idle";
         session.emitter.emit("status", sessionId, "idle");
@@ -2213,11 +2191,9 @@ Additional Cockpit rules beyond the CLI's defaults:
     // `spawning` guards the PTY startup window: the runtime is assigned before
     // its async start() resolves, and during that window ptyRuntime.isAlive is
     // false, so a second ensureProcess (a WS reconnect, or a startup race)
-    // would otherwise spawn a duplicate. The duplicate inherits the eager
-    // spawn's hasSpawnedBefore=true and --resumes a session the CLI never
-    // persisted, surfacing "No conversation found with session ID" before the
-    // user has sent anything. (Stream sets session.process synchronously, so it
-    // is already covered by that check.)
+    // would otherwise spawn a duplicate CLI for the same session — two
+    // processes racing on the same --session-id. (Stream sets session.process
+    // synchronously, so it is already covered by that check.)
     if (!session || session.process || session.ptyRuntime?.isAlive || session.spawning) return;
     this.spawnProcess(session, sessionId);
   }
@@ -2244,7 +2220,8 @@ Additional Cockpit rules beyond the CLI's defaults:
       return;
     }
 
-    this.log(sessionId, `spawning CLI process (resume=${session.hasSpawnedBefore}, model=${session.info.model || "sonnet"})`);
+    const willResume = transcriptExists(session.cliSessionId, session.info.cwd);
+    this.log(sessionId, `spawning CLI process (resume=${willResume}, model=${session.info.model || "sonnet"})`);
     const args = ["-p", "--verbose", "--output-format", "stream-json", "--input-format", "stream-json"];
 
     // In plan mode, omit --allow-dangerously-skip-permissions so the CLI
@@ -2262,7 +2239,7 @@ Additional Cockpit rules beyond the CLI's defaults:
       args.push("--permission-mode", "bypassPermissions");
     }
 
-    if (session.hasSpawnedBefore || transcriptExists(session.cliSessionId, session.info.cwd)) {
+    if (willResume) {
       args.push("--resume", session.cliSessionId);
     } else {
       args.push("--session-id", session.cliSessionId);
@@ -2343,7 +2320,6 @@ Additional Cockpit rules beyond the CLI's defaults:
 
     session.process = proc;
     session.stdin = proc.stdin!;
-    session.hasSpawnedBefore = true;
     this.log(sessionId, `CLI process spawned (pid=${proc.pid})`);
 
     this.startTodoWatcher(session, sessionId);
@@ -2517,10 +2493,10 @@ Additional Cockpit rules beyond the CLI's defaults:
       return;
     }
 
-    this.log(sessionId, `spawning PTY claude (resume=${session.hasSpawnedBefore}, model=${session.info.model || "sonnet"})`);
+    const willResume = transcriptExists(session.cliSessionId, session.info.cwd);
+    this.log(sessionId, `spawning PTY claude (resume=${willResume}, model=${session.info.model || "sonnet"})`);
     const spawnBeginAt = Date.now();
     logDiag(sessionId, "pty:spawn-begin", {
-      hasSpawnedBefore: session.hasSpawnedBefore,
       model: session.info.model,
       hasText: !!text,
       status: session.info.status,
@@ -2532,7 +2508,7 @@ Additional Cockpit rules beyond the CLI's defaults:
     streamState.thinkingStartedAt = Date.now();
 
     const extraArgs: string[] = [];
-    if (session.hasSpawnedBefore || transcriptExists(session.cliSessionId, session.info.cwd)) {
+    if (transcriptExists(session.cliSessionId, session.info.cwd)) {
       extraArgs.push("--resume", session.cliSessionId);
     } else {
       extraArgs.push("--session-id", session.cliSessionId);
@@ -2644,7 +2620,6 @@ Additional Cockpit rules beyond the CLI's defaults:
     });
 
     session.ptyRuntime = runtime;
-    session.hasSpawnedBefore = true;
     logDiag(sessionId, "pty:runtime-assigned", { elapsedMs: Date.now() - spawnBeginAt });
 
     this.cleanupAttachments(session);

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -134,9 +134,12 @@ interface Session {
   cockpitAgentCleanups: (() => void)[];
   mcpToken?: string;
   runContext?: RunContext;
-  /** True while a PTY spawn is in flight (status is "running" but the PTY is
-   *  not yet alive). Observability only -- lets the stale-check log distinguish
-   *  "process died" from "process still spawning". Does not gate any behavior. */
+  /** True while a PTY spawn is in flight: set immediately before the async
+   *  PtyRuntime.start() and cleared when it resolves, rejects, or the PTY exits.
+   *  Gates ensureProcess so a reconnect or startup race cannot spawn a duplicate
+   *  PTY during the start() window (the runtime is assigned but its isAlive is
+   *  still false). Also read by the stale-check log to tell "process died" from
+   *  "still spawning". */
   spawning?: boolean;
   transcriptWatcher: TranscriptWatcher | null;
   todoWatcher: TodoWatcher | null;
@@ -2207,7 +2210,15 @@ Additional Cockpit rules beyond the CLI's defaults:
 
   ensureProcess(sessionId: string): void {
     const session = this.sessions.get(sessionId);
-    if (!session || session.process || session.ptyRuntime?.isAlive) return;
+    // `spawning` guards the PTY startup window: the runtime is assigned before
+    // its async start() resolves, and during that window ptyRuntime.isAlive is
+    // false, so a second ensureProcess (a WS reconnect, or a startup race)
+    // would otherwise spawn a duplicate. The duplicate inherits the eager
+    // spawn's hasSpawnedBefore=true and --resumes a session the CLI never
+    // persisted, surfacing "No conversation found with session ID" before the
+    // user has sent anything. (Stream sets session.process synchronously, so it
+    // is already covered by that check.)
+    if (!session || session.process || session.ptyRuntime?.isAlive || session.spawning) return;
     this.spawnProcess(session, sessionId);
   }
 
@@ -2508,7 +2519,6 @@ Additional Cockpit rules beyond the CLI's defaults:
 
     this.log(sessionId, `spawning PTY claude (resume=${session.hasSpawnedBefore}, model=${session.info.model || "sonnet"})`);
     const spawnBeginAt = Date.now();
-    session.spawning = true;
     logDiag(sessionId, "pty:spawn-begin", {
       hasSpawnedBefore: session.hasSpawnedBefore,
       model: session.info.model,
@@ -2668,6 +2678,11 @@ Additional Cockpit rules beyond the CLI's defaults:
 
     this.startTodoWatcher(session, sessionId);
 
+    // Set the in-flight guard immediately before start(). Everything above is
+    // synchronous (no re-entrancy is possible until start() yields to the event
+    // loop), so a synchronous throw in the setup above can never strand
+    // spawning=true and permanently block ensureProcess for this session.
+    session.spawning = true;
     runtime
       .start(ptyText)
       .then(() => {

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -792,9 +792,7 @@ export class SessionManager {
     }
 
     this.killProcess(session);
-    if (!transcriptExists(session.cliSessionId, session.info.cwd)) {
-      session.hasSpawnedBefore = false;
-    }
+    this.recomputeResumeEligibility(session);
     session.pendingRequests.clear();
     this.notifyPendingChanged(session, sessionId);
     session.streamingSnapshot = null;
@@ -1100,7 +1098,7 @@ export class SessionManager {
     if (!session.process && !session.ptyRuntime?.isAlive) return;
     if (session.info.status === "idle") {
       this.killProcess(session);
-      session.hasSpawnedBefore = transcriptExists(session.cliSessionId, session.info.cwd);
+      this.recomputeResumeEligibility(session);
     } else {
       session.needsRespawnForPermissions = true;
     }
@@ -1113,6 +1111,7 @@ export class SessionManager {
     session.info.runtime = runtime;
     setSessionPrefs(sessionId, { runtime });
     this.killProcess(session);
+    this.recomputeResumeEligibility(session);
     this.emitInfoUpdated(session, sessionId);
     return true;
   }
@@ -1132,6 +1131,7 @@ export class SessionManager {
     // which lets the CLI natively enforce plan mode tool restrictions.
     if (session.process || session.ptyRuntime?.isAlive) {
       this.killProcess(session);
+      this.recomputeResumeEligibility(session);
       session.info.status = "idle";
       session.emitter.emit("status", sessionId, "idle");
     }
@@ -1150,6 +1150,7 @@ export class SessionManager {
     // restoring bypass capability for build mode.
     if (session.process || session.ptyRuntime?.isAlive) {
       this.killProcess(session);
+      this.recomputeResumeEligibility(session);
       session.info.status = "idle";
       session.emitter.emit("status", sessionId, "idle");
     }
@@ -1233,9 +1234,7 @@ export class SessionManager {
     } else {
       this.log(sessionId, `setModel: killing process (hasStdin=${!!session.stdin}, contextChanged=${contextChanged})`);
       this.killProcess(session);
-      if (!transcriptExists(session.cliSessionId, session.info.cwd)) {
-        session.hasSpawnedBefore = false;
-      }
+      this.recomputeResumeEligibility(session);
       session.queuedMessages.length = 0;
       session.queuePaused = false;
       session.info.status = "idle";
@@ -1264,6 +1263,7 @@ export class SessionManager {
       this.setModel(sessionId, modelId);
     } else {
       this.killProcess(session);
+      this.recomputeResumeEligibility(session);
       session.queuedMessages.length = 0;
       session.queuePaused = false;
       session.info.status = "idle";
@@ -1292,6 +1292,7 @@ export class SessionManager {
       session.stdin.write(JSON.stringify(request) + "\n");
     } else if (!session.stdin) {
       this.killProcess(session);
+      this.recomputeResumeEligibility(session);
       session.queuedMessages.length = 0;
       session.queuePaused = false;
       session.info.status = "idle";
@@ -1594,6 +1595,18 @@ export class SessionManager {
     session.compacting = false;
   }
 
+  /**
+   * Recompute whether the next spawn may --resume, after killing the CLI for a
+   * settings change. hasSpawnedBefore is set at spawn time, before the CLI
+   * persists a transcript, so a kill-then-respawn before the first turn would
+   * otherwise --resume a session the CLI never wrote (it exits at startup:
+   * "session cannot be found"). A transcript on disk is the only durable proof
+   * the session is resumable, so derive the flag from it.
+   */
+  private recomputeResumeEligibility(session: Session): void {
+    session.hasSpawnedBefore = transcriptExists(session.cliSessionId, session.info.cwd);
+  }
+
   private emitSystem(session: Session, sessionId: string, text: string): void {
     session.emitter.emit("system", sessionId, text);
   }
@@ -1863,6 +1876,7 @@ export class SessionManager {
         }
         this.log(sessionId, `/model command: args="${args}", was=${session.info.model}`);
         this.killProcess(session);
+        this.recomputeResumeEligibility(session);
         session.info.model = args;
         session.info.status = "idle";
         session.emitter.emit("status", sessionId, "idle");

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/server/debug-logger", () => ({
 vi.mock("@/server/transcript", () => ({
   loadTranscript: () => Promise.resolve({ messages: [], byteOffset: 0, totalSize: 0, lastUsage: null }),
   loadMoreMessages: () => Promise.resolve({ messages: [], newByteOffset: 0 }),
-  transcriptExists: () => false,
+  transcriptExists: vi.fn(() => false),
   findSessionCwd: () => Promise.resolve(null),
   getTranscriptPath: () => "/tmp/fake-transcript.jsonl",
   loadPromptHistory: () => Promise.resolve([]),
@@ -76,6 +76,11 @@ vi.mock("@/server/singleton", () => ({
     unregister: vi.fn(),
   })),
   getSessionManager: vi.fn(),
+  getCockpitMcp: vi.fn(() => ({
+    callTool: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(false),
+    getUrl: vi.fn(() => "http://127.0.0.1:3001"),
+  })),
 }));
 
 vi.mock("@/server/transcript-watcher", () => {
@@ -4142,6 +4147,247 @@ describe("SessionManager", () => {
       const session = manager.createSession("/tmp", undefined, { cockpitAgent: true, bypassPermissions: true });
       const s = (manager as any).sessions.get(session.id);
       expect(s.bypassAllPermissions).toBe(false);
+    });
+  });
+
+  describe("settings change on PTY session before first message", () => {
+    it("setThinkingLevel resets hasSpawnedBefore when PTY is killed and no transcript exists", async () => {
+      const session = manager.createSession("/tmp", "PTY-think-flag", { runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+
+      // Eagerly spawn the PTY
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+      expect(s.hasSpawnedBefore).toBe(true);
+
+      // Change thinking level (default is "high", so changing to "low" triggers a kill)
+      manager.setThinkingLevel(session.id, "low");
+
+      // hasSpawnedBefore should be reset since there's no transcript
+      expect(s.hasSpawnedBefore).toBe(false);
+    });
+
+    it("setThinkingLevel uses --session-id (not --resume) on respawn", async () => {
+      const session = manager.createSession("/tmp", "PTY-think-respawn", { runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+
+      // Change thinking level (kills the PTY)
+      manager.setThinkingLevel(session.id, "low");
+
+      // Now send first message, triggering a new PTY spawn
+      capturedPtyOpts = null;
+      s.info.status = "idle";
+      manager.sendMessage(session.id, "hello");
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+
+      const args = capturedPtyOpts!.extraArgs as string[];
+      expect(args).toContain("--session-id");
+      expect(args).not.toContain("--resume");
+    });
+
+    it("setRuntime kills process and recomputes resume eligibility", async () => {
+      const session = manager.createSession("/tmp", "PTY-runtime", { runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+      expect(s.hasSpawnedBefore).toBe(true);
+
+      // Switch to stream runtime — kills PTY, recomputes
+      manager.setRuntime(session.id, "stream");
+      expect(s.hasSpawnedBefore).toBe(false);
+
+      // Stream spawn path — assert on vi.mocked(spawn), not capturedPtyOpts
+      const mockSpawn = vi.mocked(spawn);
+      s.info.status = "idle";
+      manager.sendMessage(session.id, "hello");
+      const lastSpawnArgs = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1][1] as string[];
+      expect(lastSpawnArgs).toContain("--session-id");
+      expect(lastSpawnArgs).not.toContain("--resume");
+    });
+
+    it("setPlanMode uses --session-id (not --resume) on respawn", async () => {
+      const session = manager.createSession("/tmp", "PTY-planmode", { runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+      expect(s.hasSpawnedBefore).toBe(true);
+
+      // Enter plan mode — kills the PTY
+      manager.setPlanMode(session.id);
+      expect(s.hasSpawnedBefore).toBe(false);
+
+      // Send first message
+      capturedPtyOpts = null;
+      s.info.status = "idle";
+      manager.sendMessage(session.id, "hello");
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+
+      const args = capturedPtyOpts!.extraArgs as string[];
+      expect(args).toContain("--session-id");
+      expect(args).not.toContain("--resume");
+      expect(args).toContain("--permission-mode");
+      expect(args[args.indexOf("--permission-mode") + 1]).toBe("plan");
+    });
+
+    it("clearPlanMode uses --session-id (not --resume) on respawn", async () => {
+      const session = manager.createSession("/tmp", "PTY-clearmode", { runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+
+      // Set plan mode first (no live process yet — no kill)
+      manager.setPlanMode(session.id);
+
+      // Eagerly spawn the PTY (in plan mode)
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+      expect(s.hasSpawnedBefore).toBe(true);
+
+      // Clear plan mode — process is alive, so it kills + recomputes
+      manager.clearPlanMode(session.id);
+      expect(s.hasSpawnedBefore).toBe(false);
+
+      // Send first message
+      capturedPtyOpts = null;
+      s.info.status = "idle";
+      manager.sendMessage(session.id, "hello");
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+
+      const args = capturedPtyOpts!.extraArgs as string[];
+      expect(args).toContain("--session-id");
+      expect(args).not.toContain("--resume");
+    });
+
+    it("setModelSlot non-main uses --session-id (not --resume) on respawn", async () => {
+      const session = manager.createSession("/tmp", "PTY-slots", { runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+      expect(s.hasSpawnedBefore).toBe(true);
+
+      // Set a non-main model slot (kills the PTY)
+      manager.setModelSlot(session.id, "fast", "haiku");
+      expect(s.hasSpawnedBefore).toBe(false);
+
+      // Send first message
+      capturedPtyOpts = null;
+      s.info.status = "idle";
+      manager.sendMessage(session.id, "hello");
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+
+      const args = capturedPtyOpts!.extraArgs as string[];
+      expect(args).toContain("--session-id");
+      expect(args).not.toContain("--resume");
+    });
+
+    it("/model slash command uses --session-id (not --resume) on respawn", async () => {
+      const session = manager.createSession("/tmp", "PTY-slash", { runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+      expect(s.hasSpawnedBefore).toBe(true);
+
+      // Send /model opus as the first message (intercepted by handleCommand, kills)
+      manager.sendMessage(session.id, "/model opus");
+
+      // Now send a real message
+      capturedPtyOpts = null;
+      s.info.status = "idle";
+      manager.sendMessage(session.id, "hello");
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+
+      const args = capturedPtyOpts!.extraArgs as string[];
+      expect(args).toContain("--session-id");
+      expect(args).not.toContain("--resume");
+    });
+
+    it("cockpit agent uses --session-id (not --resume) after setThinkingLevel before first message", async () => {
+      const session = manager.createSession("/tmp", undefined, { cockpitAgent: true, runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+      expect(s.hasSpawnedBefore).toBe(true);
+
+      // Change thinking level
+      manager.setThinkingLevel(session.id, "low");
+
+      // Send first message
+      capturedPtyOpts = null;
+      s.info.status = "idle";
+      manager.sendMessage(session.id, "hello");
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+
+      const args = capturedPtyOpts!.extraArgs as string[];
+      expect(args).toContain("--session-id");
+      expect(args).not.toContain("--resume");
+    });
+
+    it("cockpit agent uses --session-id (not --resume) after setModel before first message", async () => {
+      const session = manager.createSession("/tmp", undefined, { cockpitAgent: true, runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+      expect(s.hasSpawnedBefore).toBe(true);
+
+      // Change model
+      s.ptyRuntime = null;
+      manager.setModel(session.id, "opus");
+
+      // Send first message
+      capturedPtyOpts = null;
+      s.info.status = "idle";
+      manager.sendMessage(session.id, "hello");
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+
+      const args = capturedPtyOpts!.extraArgs as string[];
+      expect(args).toContain("--session-id");
+      expect(args).not.toContain("--resume");
+    });
+
+    it("regression: transcript exists keeps --resume after settings change", async () => {
+      // Override transcriptExists mock to return true (as if a mid-session change)
+      const transcriptModule = await import("@/server/transcript");
+      vi.mocked(transcriptModule.transcriptExists).mockReturnValue(true);
+      try {
+        const session = manager.createSession("/tmp", "PTY-transcript", { runtime: "pty" });
+        const s = (manager as any).sessions.get(session.id)!;
+
+        capturedPtyOpts = null;
+        manager.ensureProcess(session.id);
+        await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+        expect(s.hasSpawnedBefore).toBe(true);
+
+        // Change thinking level (guarded setter — helper recomputes from transcriptExists)
+        manager.setThinkingLevel(session.id, "low");
+
+        // Send first message
+        capturedPtyOpts = null;
+        s.info.status = "idle";
+        manager.sendMessage(session.id, "hello");
+        await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+
+        const args = capturedPtyOpts!.extraArgs as string[];
+        expect(args).toContain("--resume");
+        expect(args).not.toContain("--session-id");
+      } finally {
+        vi.mocked(transcriptModule.transcriptExists).mockReturnValue(false);
+      }
     });
   });
 

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -4391,6 +4391,35 @@ describe("SessionManager", () => {
     });
   });
 
+  describe("ensureProcess concurrency guard", () => {
+    it("does not spawn while a PTY spawn is in flight (session.spawning)", () => {
+      const session = manager.createSession("/tmp", "PTY-spawning", { runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+
+      // Simulate the PTY startup window: spawning is set, but the runtime is
+      // not yet alive (ptyRuntime assigned before start() resolves, isAlive
+      // false). A second ensureProcess here must NOT spawn a duplicate.
+      s.spawning = true;
+      s.ptyRuntime = null;
+
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+
+      expect(capturedPtyOpts).toBeNull();
+    });
+
+    it("spawns when idle with no in-flight spawn", async () => {
+      const session = manager.createSession("/tmp", "PTY-idle", { runtime: "pty" });
+      const s = (manager as any).sessions.get(session.id)!;
+      expect(s.spawning).toBeFalsy();
+
+      capturedPtyOpts = null;
+      manager.ensureProcess(session.id);
+
+      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+    });
+  });
+
   describe("cockpit agent permission handling", () => {
     it("auto-approves Read tool", () => {
       const session = manager.createSession("/tmp", undefined, { cockpitAgent: true });

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -3570,22 +3570,26 @@ describe("SessionManager", () => {
       expect(args).toContain("--allow-dangerously-skip-permissions");
     });
 
-    it("passes --resume when hasSpawnedBefore is true", () => {
-      const mockSpawn = vi.mocked(spawn);
-      const session = manager.createSession("/tmp");
-      const s = (manager as any).sessions.get(session.id)!;
-      s.hasSpawnedBefore = true;
+    it("passes --resume when a transcript exists", async () => {
+      const transcriptModule = await import("@/server/transcript");
+      vi.mocked(transcriptModule.transcriptExists).mockReturnValue(true);
+      try {
+        const mockSpawn = vi.mocked(spawn);
+        const session = manager.createSession("/tmp");
+        const s = (manager as any).sessions.get(session.id)!;
 
-      (manager as any).spawnProcess(s, session.id);
-      const args = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1][1] as string[];
-      expect(args).toContain("--resume");
+        (manager as any).spawnProcess(s, session.id);
+        const args = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1][1] as string[];
+        expect(args).toContain("--resume");
+      } finally {
+        vi.mocked(transcriptModule.transcriptExists).mockReturnValue(false);
+      }
     });
 
-    it("passes --session-id when not previously spawned", () => {
+    it("passes --session-id when no transcript exists", () => {
       const mockSpawn = vi.mocked(spawn);
       const session = manager.createSession("/tmp");
       const s = (manager as any).sessions.get(session.id)!;
-      s.hasSpawnedBefore = false;
 
       (manager as any).spawnProcess(s, session.id);
       const args = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1][1] as string[];
@@ -4035,23 +4039,6 @@ describe("SessionManager", () => {
   });
 
   describe("setModel on PTY session before first message", () => {
-    it("resets hasSpawnedBefore when PTY is killed and no transcript exists", async () => {
-      const session = manager.createSession("/tmp/pty-model", "PTY", { runtime: "pty" });
-      const s = (manager as any).sessions.get(session.id)!;
-
-      // Simulate ensureProcess having eagerly spawned the PTY
-      capturedPtyOpts = null;
-      manager.ensureProcess(session.id);
-      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-      expect(s.hasSpawnedBefore).toBe(true);
-
-      // User changes model before sending any message. setModel kills PTY.
-      manager.setModel(session.id, "opus");
-
-      // hasSpawnedBefore should be reset since there's no transcript
-      expect(s.hasSpawnedBefore).toBe(false);
-    });
-
     it("uses --session-id (not --resume) on respawn after model change", async () => {
       const session = manager.createSession("/tmp/pty-model2", "PTY", { runtime: "pty" });
       const s = (manager as any).sessions.get(session.id)!;
@@ -4088,7 +4075,6 @@ describe("SessionManager", () => {
 
       // First spawn (e.g. via ensureProcess or sendMessage)
       (manager as any).spawnProcess(s, session.id);
-      expect(s.hasSpawnedBefore).toBe(true);
 
       // Kill the process to simulate idle state
       s.process = null;
@@ -4111,7 +4097,6 @@ describe("SessionManager", () => {
       capturedPtyOpts = null;
       manager.ensureProcess(session.id);
       await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-      expect(s.hasSpawnedBefore).toBe(true);
 
       // Kill the ptyRuntime to simulate idle
       s.ptyRuntime = null;
@@ -4151,23 +4136,6 @@ describe("SessionManager", () => {
   });
 
   describe("settings change on PTY session before first message", () => {
-    it("setThinkingLevel resets hasSpawnedBefore when PTY is killed and no transcript exists", async () => {
-      const session = manager.createSession("/tmp", "PTY-think-flag", { runtime: "pty" });
-      const s = (manager as any).sessions.get(session.id)!;
-
-      // Eagerly spawn the PTY
-      capturedPtyOpts = null;
-      manager.ensureProcess(session.id);
-      await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-      expect(s.hasSpawnedBefore).toBe(true);
-
-      // Change thinking level (default is "high", so changing to "low" triggers a kill)
-      manager.setThinkingLevel(session.id, "low");
-
-      // hasSpawnedBefore should be reset since there's no transcript
-      expect(s.hasSpawnedBefore).toBe(false);
-    });
-
     it("setThinkingLevel uses --session-id (not --resume) on respawn", async () => {
       const session = manager.createSession("/tmp", "PTY-think-respawn", { runtime: "pty" });
       const s = (manager as any).sessions.get(session.id)!;
@@ -4190,18 +4158,16 @@ describe("SessionManager", () => {
       expect(args).not.toContain("--resume");
     });
 
-    it("setRuntime kills process and recomputes resume eligibility", async () => {
+    it("setRuntime uses --session-id (not --resume) on respawn before first turn", async () => {
       const session = manager.createSession("/tmp", "PTY-runtime", { runtime: "pty" });
       const s = (manager as any).sessions.get(session.id)!;
 
       capturedPtyOpts = null;
       manager.ensureProcess(session.id);
       await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-      expect(s.hasSpawnedBefore).toBe(true);
 
-      // Switch to stream runtime — kills PTY, recomputes
+      // Switch to stream runtime — kills the eager PTY before any turn.
       manager.setRuntime(session.id, "stream");
-      expect(s.hasSpawnedBefore).toBe(false);
 
       // Stream spawn path — assert on vi.mocked(spawn), not capturedPtyOpts
       const mockSpawn = vi.mocked(spawn);
@@ -4219,11 +4185,9 @@ describe("SessionManager", () => {
       capturedPtyOpts = null;
       manager.ensureProcess(session.id);
       await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-      expect(s.hasSpawnedBefore).toBe(true);
 
       // Enter plan mode — kills the PTY
       manager.setPlanMode(session.id);
-      expect(s.hasSpawnedBefore).toBe(false);
 
       // Send first message
       capturedPtyOpts = null;
@@ -4249,11 +4213,9 @@ describe("SessionManager", () => {
       capturedPtyOpts = null;
       manager.ensureProcess(session.id);
       await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-      expect(s.hasSpawnedBefore).toBe(true);
 
       // Clear plan mode — process is alive, so it kills + recomputes
       manager.clearPlanMode(session.id);
-      expect(s.hasSpawnedBefore).toBe(false);
 
       // Send first message
       capturedPtyOpts = null;
@@ -4273,11 +4235,9 @@ describe("SessionManager", () => {
       capturedPtyOpts = null;
       manager.ensureProcess(session.id);
       await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-      expect(s.hasSpawnedBefore).toBe(true);
 
       // Set a non-main model slot (kills the PTY)
       manager.setModelSlot(session.id, "fast", "haiku");
-      expect(s.hasSpawnedBefore).toBe(false);
 
       // Send first message
       capturedPtyOpts = null;
@@ -4297,7 +4257,6 @@ describe("SessionManager", () => {
       capturedPtyOpts = null;
       manager.ensureProcess(session.id);
       await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-      expect(s.hasSpawnedBefore).toBe(true);
 
       // Send /model opus as the first message (intercepted by handleCommand, kills)
       manager.sendMessage(session.id, "/model opus");
@@ -4320,7 +4279,6 @@ describe("SessionManager", () => {
       capturedPtyOpts = null;
       manager.ensureProcess(session.id);
       await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-      expect(s.hasSpawnedBefore).toBe(true);
 
       // Change thinking level
       manager.setThinkingLevel(session.id, "low");
@@ -4343,7 +4301,6 @@ describe("SessionManager", () => {
       capturedPtyOpts = null;
       manager.ensureProcess(session.id);
       await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-      expect(s.hasSpawnedBefore).toBe(true);
 
       // Change model
       s.ptyRuntime = null;
@@ -4371,12 +4328,36 @@ describe("SessionManager", () => {
         capturedPtyOpts = null;
         manager.ensureProcess(session.id);
         await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
-        expect(s.hasSpawnedBefore).toBe(true);
 
         // Change thinking level (guarded setter — helper recomputes from transcriptExists)
         manager.setThinkingLevel(session.id, "low");
 
         // Send first message
+        capturedPtyOpts = null;
+        s.info.status = "idle";
+        manager.sendMessage(session.id, "hello");
+        await vi.waitFor(() => expect(capturedPtyOpts).not.toBeNull());
+
+        const args = capturedPtyOpts!.extraArgs as string[];
+        expect(args).toContain("--resume");
+        expect(args).not.toContain("--session-id");
+      } finally {
+        vi.mocked(transcriptModule.transcriptExists).mockReturnValue(false);
+      }
+    });
+  });
+
+  describe("resume eligibility (transcript-based)", () => {
+    it("a settings change after a persisted turn still resumes", async () => {
+      // A real turn writes the CLI transcript to disk; model that with the mock.
+      // The respawn must --resume so conversation context survives the change.
+      const transcriptModule = await import("@/server/transcript");
+      vi.mocked(transcriptModule.transcriptExists).mockReturnValue(true);
+      try {
+        const session = manager.createSession("/tmp", "PTY-turn-resume", { runtime: "pty" });
+        const s = (manager as any).sessions.get(session.id)!;
+
+        manager.setThinkingLevel(session.id, "low");
         capturedPtyOpts = null;
         s.info.status = "idle";
         manager.sendMessage(session.id, "hello");


### PR DESCRIPTION
## Summary

Fixes ALE-601 — changing a setting (thinking level, model, runtime, plan mode) before sending the first message broke the session — plus a related idle-open failure surfaced during review. In both cases the CLI was asked to `--resume` a session it had never persisted and exited at startup with "No conversation found with session ID".

**Root cause:** the `--resume` decision keyed off `hasSpawnedBefore`, a flag set at spawn time, before the CLI writes any transcript. Any respawn before the first turn — a settings-change kill, the eager-spawn race on session open, or a WS reconnect — then resumed a session that didn't exist.

## Changes

- **Resume eligibility (`src/server/session-manager.ts`):** decide `--resume` vs `--session-id` purely on `transcriptExists(cliSessionId, cwd)`, the actual precondition for resume. The `hasSpawnedBefore` flag is removed entirely. This fixes every respawn-before-first-turn path at a single point.
- **Spawn concurrency guard:** `ensureProcess` skips while a PTY spawn is in flight (`session.spawning`), so a reconnect or startup race can't launch a duplicate CLI for the same session. `killProcess` clears the guard so a deliberate kill-then-respawn isn't blocked.
- **Review-server harness (`.claude/skills/implement-issue`):** strip inherited provider `ANTHROPIC_*` env vars when launching the review server, so a custom-provider agent run can't leak its model/endpoint into the test server (the UI showed Sonnet while the CLI ran a different provider). Tooling only; no app behaviour change.

## Why transcript-based

A flag-at-first-turn-completion variant was tried first, but review found it fragile: `pty-runtime` synthesizes a `message_done` on an API error, which would falsely mark a never-persisted session resumable and reproduce the exact bug on a first-turn error. The on-disk transcript check can't be fooled by that, or by a flag set too early at spawn.

## Acceptance criteria

- [x] Changing thinking level / model / runtime / plan mode before the first message no longer errors; the first message starts a fresh session.
- [x] The `/model` command issued before any real message behaves the same.
- [x] Cockpit-agent PTY sessions behave the same when model or thinking is changed before the first message.
- [x] Opening a session and leaving it idle no longer surfaces "No conversation found".
- [x] A settings change after a real turn still resumes (conversation context preserved).
- [x] `tsc --noEmit`, `npm run build`, `npm run lint`, and full `vitest` all pass.

## Verification

- `tsc --noEmit`, `npm run build`, `npm run lint`, full `vitest` (1514 passing) all green.
- Tests assert spawn args (`--resume` when a transcript exists, `--session-id` otherwise) across the affected setters, the cockpit agent, the `/model` command, the idle-open spawn guard, and a mid-session resume.
- Manually verified on the review server: idle-open no longer errors; settings changes before and after the first message behave correctly; the model picker reports the real Anthropic model.

## Follow-ups

- **ALE-634** — isolate built-in-provider spawns from ambient env (cockpit-side, beyond the skill workaround).
- Pre-existing, out of scope: `sendMessage` during the spawn-startup window can still double-spawn (not the reported bug, which was idle-open with no message sent).

Closes ALE-601.
