### PR TITLE
fix(jobs): allow clearing the max duration and retention fields without snap-back to 0

### DIFF
--- a/src/app/(app)/jobs/[id]/edit/page.tsx
+++ b/src/app/(app)/jobs/[id]/edit/page.tsx
@@ -19,6 +19,8 @@ import {
   resolveModel,
   versionsForAlias,
 } from "@/lib/models";
+import { isPositiveNumberField, parseNumberField } from "@/lib/number-field";
+import { cn } from "@/lib/utils";
 import { describeSchedule, getJobSchedules } from "@/server/cron-utils";
 import type { JobSchedule, Provider, ProviderModel, ScheduledJob, SimpleSchedule, SimpleScheduleFrequency, ThinkingLevel } from "@/types";
 
@@ -169,7 +171,7 @@ export default function JobEditPage() {
   const [selectedProviderId, setSelectedProviderId] = useState("anthropic");
   const [runtime, setRuntime] = useState<"stream" | "pty">("stream");
 
-  const [maxDuration, setMaxDuration] = useState(30);
+  const [maxDuration, setMaxDuration] = useState<number | "">(30);
   const [bypassPermissions, setBypassPermissions] = useState(false);
   const [allowedTools, setAllowedTools] = useState<string[]>([]);
   const [toolInput, setToolInput] = useState("");
@@ -182,7 +184,7 @@ export default function JobEditPage() {
   const [mcpToolsLoading, setMcpToolsLoading] = useState<Record<string, boolean>>({});
   const [availableMcp, setAvailableMcp] = useState<string[]>([]);
   const [skipIfMissed, setSkipIfMissed] = useState(false);
-  const [retentionDays, setRetentionDays] = useState(90);
+  const [retentionDays, setRetentionDays] = useState<number | "">(90);
   const [inboxOutput, setInboxOutput] = useState(false);
   const [notifyProviders, setNotifyProviders] = useState<string[]>([]);
   const [availableProviders, setAvailableProviders] = useState<{ id: string; name: string; type: string }[]>([]);
@@ -190,6 +192,7 @@ export default function JobEditPage() {
 
   const [showDirPicker, setShowDirPicker] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<{ maxDuration?: string; retentionDays?: string }>({});
   const [loading, setLoading] = useState(!isNew || !!duplicateFrom);
 
   const isBuiltinProvider = selectedProviderId === "anthropic";
@@ -389,6 +392,14 @@ export default function JobEditPage() {
   }, []);
 
   async function handleSave() {
+    const durationValid = isPositiveNumberField(maxDuration);
+    const retentionValid = isPositiveNumberField(retentionDays);
+    setFieldErrors({
+      maxDuration: durationValid ? undefined : "Enter a duration of at least 1 minute.",
+      retentionDays: retentionValid ? undefined : "Enter a retention of at least 1 day.",
+    });
+    if (!durationValid || !retentionValid) return;
+
     setSaving(true);
     let modelStr = modelId;
     if (!isBuiltinProvider && selectedProviderId) {
@@ -910,7 +921,14 @@ export default function JobEditPage() {
 
             <div className="space-y-1.5">
               <label className="text-sm font-medium">Max Duration (minutes)</label>
-              <Input type="number" min={1} value={maxDuration} onChange={(e) => setMaxDuration(Number(e.target.value))} />
+              <Input
+                type="number"
+                min={1}
+                value={maxDuration}
+                onChange={(e) => setMaxDuration(parseNumberField(e.target.value))}
+                className={cn(fieldErrors.maxDuration && "border-destructive")}
+              />
+              {fieldErrors.maxDuration && <p className="text-xs text-destructive">{fieldErrors.maxDuration}</p>}
             </div>
 
             <div className="flex items-center justify-between">
@@ -920,7 +938,14 @@ export default function JobEditPage() {
 
             <div className="space-y-1.5">
               <label className="text-sm font-medium">Audit log retention (days)</label>
-              <Input type="number" min={1} value={retentionDays} onChange={(e) => setRetentionDays(Number(e.target.value))} />
+              <Input
+                type="number"
+                min={1}
+                value={retentionDays}
+                onChange={(e) => setRetentionDays(parseNumberField(e.target.value))}
+                className={cn(fieldErrors.retentionDays && "border-destructive")}
+              />
+              {fieldErrors.retentionDays && <p className="text-xs text-destructive">{fieldErrors.retentionDays}</p>}
             </div>
           </CardContent>
         </Card>

--- a/src/lib/number-field.ts
+++ b/src/lib/number-field.ts
@@ -1,0 +1,13 @@
+/**
+ * Coerce a number <input>'s raw string value while preserving an empty field.
+ * Number("") is 0, which makes a controlled number input snap back to 0 and
+ * traps the caret after it. Returning "" lets the field be cleared.
+ */
+export function parseNumberField(raw: string): number | "" {
+  return raw === "" ? "" : Number(raw);
+}
+
+/** True when value is a finite number >= 1 (a valid duration/retention entry). */
+export function isPositiveNumberField(value: number | ""): value is number {
+  return value !== "" && Number.isFinite(value) && value >= 1;
+}

--- a/tests/number-field.test.ts
+++ b/tests/number-field.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { isPositiveNumberField, parseNumberField } from "../src/lib/number-field";
+
+describe("parseNumberField", () => {
+  it("returns empty string for empty input", () => {
+    expect(parseNumberField("")).toBe("");
+  });
+
+  it("parses a positive integer string", () => {
+    expect(parseNumberField("120")).toBe(120);
+  });
+
+  it("parses zero", () => {
+    expect(parseNumberField("0")).toBe(0);
+  });
+
+  it("parses a decimal string", () => {
+    expect(parseNumberField("12.5")).toBe(12.5);
+  });
+});
+
+describe("isPositiveNumberField", () => {
+  it("returns false for empty string", () => {
+    expect(isPositiveNumberField("")).toBe(false);
+  });
+
+  it("returns false for zero", () => {
+    expect(isPositiveNumberField(0)).toBe(false);
+  });
+
+  it("returns false for a negative number", () => {
+    expect(isPositiveNumberField(-3)).toBe(false);
+  });
+
+  it("returns false for NaN", () => {
+    expect(isPositiveNumberField(NaN)).toBe(false);
+  });
+
+  it("returns true for 1", () => {
+    expect(isPositiveNumberField(1)).toBe(true);
+  });
+
+  it("returns true for a positive number", () => {
+    expect(isPositiveNumberField(120)).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes ALE-633.

## Summary

The Max Duration (minutes) and Audit log retention (days) number fields on the job edit form snap back to 0 when cleared, because `Number("") === 0`. This traps the caret and forces the user to manually position the cursor before typing.

## Changes

- **New** `src/lib/number-field.ts`: `parseNumberField` and `isPositiveNumberField` helpers that preserve empty-string clearing and validate at save time.
- **Changed** `src/app/(app)/jobs/[id]/edit/page.tsx`: widens both state types to `number | ""`, uses `parseNumberField` in onChange, validates in `handleSave` before `setSaving(true)`, applies `border-destructive` and inline error messages when invalid.
- **New** `tests/number-field.test.ts`: full branch coverage of the helper module.

## Acceptance Criteria

- [x] Max Duration field can be cleared and shows empty while editing; no snap-back to 0.
- [x] Typing into a cleared field produces exactly that value.
- [x] Saving with empty/invalid fields is blocked, red border and inline message shown.
- [x] Audit log retention field receives identical treatment.
- [x] Editing an existing job loads stored values; new job defaults to 30 and 90.
- [x] Valid save sends numeric payload (never empty string).
- [x] Helper module unit-tested; coverage gate passes (88.82% statements, 80.38% branches).
- [x] Both fields show validation errors simultaneously.

## Deviations from plan

None.

## Review

Code review: PASS (1 round, no findings on ALE-633 changes). UI review: PASS (all criteria confirmed via Playwright). Completeness check: PASS (one interaction criterion deferred to ui-reviewer, confirmed there).