### PR TITLE
fix(queued): render paste chips instead of expanded file content on flush (ALE-600)

### DIFF
--- a/src/hooks/message-ordering.ts
+++ b/src/hooks/message-ordering.ts
@@ -1,6 +1,46 @@
-import type { ChatMessage } from "@/types";
+import { extractTextFiles } from "@/lib/paste-detect";
+import type { ChatMessage, DocumentAttachment, ImageAttachment, TextFileAttachment } from "@/types";
 
 const stripAttachments = (s: string) => s.replace(/^\[Attached [^\]]+\]\n*/gm, "").trim();
+
+export type QueuedText = {
+  text: string;
+  apiText: string;
+  images?: ImageAttachment[];
+  documents?: DocumentAttachment[];
+  textFiles?: TextFileAttachment[];
+};
+
+/** Build the optimistic user bubble for a flushed queued message.
+ *  `sentText` is the EXPANDED apiText the server echoes back. Content is set
+ *  to the cleaned (collapsed) form so it equals what the transcript parser
+ *  produces -> applyTranscript dedups it. Paste/image/doc metadata is recovered
+ *  from the queued entry matched EXACTLY on apiText (whitespace-proof), with a
+ *  parse-from-sentText fallback for the chip if the local queue ref was cleared. */
+export function buildQueuedUserMessage(
+  sentText: string,
+  queued: QueuedText[],
+  id: string,
+  timestamp: number,
+): { message: ChatMessage; matchedIndex: number } {
+  const { cleaned, textFiles: parsed } = extractTextFiles(sentText);
+  const matchedIndex = queued.findIndex((m) => m.apiText === sentText);
+  const matched = matchedIndex !== -1 ? queued[matchedIndex] : null;
+  return {
+    matchedIndex,
+    message: {
+      id,
+      role: "user",
+      content: cleaned,
+      toolUses: [],
+      blocks: [],
+      timestamp,
+      images: matched?.images,
+      documents: matched?.documents,
+      textFiles: matched?.textFiles ?? (parsed.length > 0 ? parsed : undefined),
+    },
+  };
+}
 
 /**
  * Replace the "streaming" placeholder with a finalized assistant message,

--- a/src/hooks/use-session.ts
+++ b/src/hooks/use-session.ts
@@ -17,7 +17,7 @@ import type {
   TodoItem,
   ToolUse,
 } from "@/types";
-import { applyMessageDone, applyTranscript } from "./message-ordering";
+import { applyMessageDone, applyTranscript, buildQueuedUserMessage, type QueuedText } from "./message-ordering";
 import { useWebSocket } from "./use-websocket";
 
 export interface PendingPermission {
@@ -163,9 +163,7 @@ export function useSession(sessionId: string, cwd?: string, historyView?: boolea
   // Each is injected into the UI when the server confirms delivery
   // via session:queued sentText. Using an array (not a single ref)
   // so rapid-fire messages don't overwrite each other.
-  const queuedTextsRef = useRef<
-    Array<{ text: string; images?: ImageAttachment[]; documents?: DocumentAttachment[]; textFiles?: TextFileAttachment[] }>
-  >([]);
+  const queuedTextsRef = useRef<QueuedText[]>([]);
   const loadedSessionRef = useRef<string | null>(null);
 
   // Reset when switching sessions
@@ -801,21 +799,14 @@ export function useSession(sessionId: string, cwd?: string, historyView?: boolea
           // Inject the user message bubble now (after the assistant
           // response, before the next response starts streaming).
           if (msg.sentText) {
-            const q = queuedTextsRef.current;
-            const idx = q.findIndex((m) => m.text === msg.sentText);
-            const matched = idx !== -1 ? q.splice(idx, 1)[0] : null;
-            const userMsg: ChatMessage = {
-              id: "user-queued-" + Date.now(),
-              role: "user",
-              content: msg.sentText,
-              toolUses: [],
-              blocks: [],
-              timestamp: Date.now(),
-              images: matched?.images,
-              documents: matched?.documents,
-              textFiles: matched?.textFiles,
-            };
-            setMessages((prev) => [...prev, userMsg]);
+            const { message, matchedIndex } = buildQueuedUserMessage(
+              msg.sentText,
+              queuedTextsRef.current,
+              "user-queued-" + Date.now(),
+              Date.now(),
+            );
+            if (matchedIndex !== -1) queuedTextsRef.current.splice(matchedIndex, 1);
+            setMessages((prev) => [...prev, message]);
           }
           break;
         }
@@ -1140,7 +1131,7 @@ export function useSession(sessionId: string, cwd?: string, historyView?: boolea
 
       // Queue message server-side when responding
       if (isRespondingRef.current) {
-        queuedTextsRef.current.push({ text, images, documents, textFiles });
+        queuedTextsRef.current.push({ text, apiText, images, documents, textFiles });
         send({
           type: "message:send",
           sessionId,

--- a/src/lib/paste-detect.ts
+++ b/src/lib/paste-detect.ts
@@ -1,3 +1,19 @@
+import type { TextFileAttachment } from "@/types";
+
+const FILE_TAG_RE = /<file\s+path="([^"]+)">\n([\s\S]*?)\n<\/file>/g;
+
+export function extractTextFiles(text: string): { cleaned: string; textFiles: TextFileAttachment[] } {
+  const textFiles: TextFileAttachment[] = [];
+  const cleaned = text
+    .replace(FILE_TAG_RE, (_match, name: string, content: string) => {
+      textFiles.push({ name, content });
+      return "";
+    })
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return { cleaned, textFiles };
+}
+
 const MIN_LINES = 10;
 
 // Map Magika content type labels to file extensions for naming and syntax highlighting.

--- a/src/server/transcript.ts
+++ b/src/server/transcript.ts
@@ -3,6 +3,7 @@ import { open, readdir, readFile, stat, unlink, writeFile } from "node:fs/promis
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { v4 as uuidv4 } from "uuid";
+import { extractTextFiles } from "@/lib/paste-detect";
 import { getClaudeDir } from "@/server/paths";
 import type {
   ChatMessage,
@@ -12,7 +13,6 @@ import type {
   ImageAttachment,
   SessionGroup,
   SessionInfo,
-  TextFileAttachment,
   ToolUse,
 } from "@/types";
 import { debugLog } from "./debug-logger";
@@ -93,20 +93,6 @@ export function countTranscriptMessages(sessionId: string, cwd: string): number 
 
 const CLI_XML_RE =
   /<(?:task-notification|local-command-caveat|local-command-stdout|system-reminder)[^>]*>[\s\S]*?<\/(?:task-notification|local-command-caveat|local-command-stdout|system-reminder)>[\s\S]*/g;
-
-const FILE_TAG_RE = /<file\s+path="([^"]+)">\n([\s\S]*?)\n<\/file>/g;
-
-function extractTextFiles(text: string): { cleaned: string; textFiles: TextFileAttachment[] } {
-  const textFiles: TextFileAttachment[] = [];
-  const cleaned = text
-    .replace(FILE_TAG_RE, (_match, name: string, content: string) => {
-      textFiles.push({ name, content });
-      return "";
-    })
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-  return { cleaned, textFiles };
-}
 
 function stripCommandXml(text: string): string {
   const trimmed = text.trimStart();

--- a/tests/message-ordering.test.ts
+++ b/tests/message-ordering.test.ts
@@ -6,6 +6,17 @@ function msg(id: string, role: "user" | "assistant" | "system", content: string)
   return { id, role, content, toolUses: [], blocks: [], timestamp: Date.now() };
 }
 
+function msgWithFiles(
+  id: string,
+  role: "user" | "assistant" | "system",
+  content: string,
+  textFiles?: ChatMessage["textFiles"],
+  images?: ChatMessage["images"],
+  documents?: ChatMessage["documents"],
+): ChatMessage {
+  return { id, role, content, toolUses: [], blocks: [], timestamp: Date.now(), textFiles, images, documents };
+}
+
 describe("applyMessageDone", () => {
   it("replaces streaming with finalized message at the same position", () => {
     const prev = [msg("user-1", "user", "hello"), msg("streaming", "assistant", "response"), msg("user-queued-2", "user", "follow up")];
@@ -131,5 +142,30 @@ describe("applyTranscript", () => {
     const result = applyTranscript(prev, transcript);
 
     expect(result.map((m) => m.id)).toEqual(["server-u1", "server-a1"]);
+  });
+
+  it("deduplicates injected paste bubble against transcript message by content", () => {
+    const prev = [
+      msgWithFiles("user-queued-1", "user", "review this", [{ name: "paste.ts", content: "const x = 1" }]),
+      msg("server-a1", "assistant", "response"),
+    ];
+    const transcript = [
+      msgWithFiles("t-user-1", "user", "review this", [{ name: "paste.ts", content: "const x = 1" }]),
+      msg("server-a1", "assistant", "response"),
+    ];
+
+    const result = applyTranscript(prev, transcript);
+
+    const userMessages = result.filter((m) => m.role === "user");
+    expect(userMessages).toHaveLength(1);
+    expect(userMessages[0].id).toBe("t-user-1");
+    expect(userMessages[0].textFiles).toEqual([{ name: "paste.ts", content: "const x = 1" }]);
+  });
+
+  it("preserves textFiles on transcript user message through enrichment when no images/documents", () => {
+    const result = applyTranscript([], [msgWithFiles("t-user-1", "user", "review this", [{ name: "paste.ts", content: "const x = 1" }])]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].textFiles).toEqual([{ name: "paste.ts", content: "const x = 1" }]);
   });
 });

--- a/tests/paste-detect.test.ts
+++ b/tests/paste-detect.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { extractTextFiles } from "@/lib/paste-detect";
+
+describe("extractTextFiles", () => {
+  it("extracts a single file block and returns cleaned text", () => {
+    const result = extractTextFiles('<file path="paste.ts">\nconst x = 1\n</file>\n\nreview this');
+    expect(result.cleaned).toBe("review this");
+    expect(result.textFiles).toEqual([{ name: "paste.ts", content: "const x = 1" }]);
+  });
+
+  it("returns input as cleaned when no file block is present", () => {
+    const result = extractTextFiles("  just some text  ");
+    expect(result.cleaned).toBe("just some text");
+    expect(result.textFiles).toEqual([]);
+  });
+
+  it("handles a file block with no trailing text", () => {
+    const result = extractTextFiles('<file path="data.txt">\nhello world\n</file>');
+    expect(result.cleaned).toBe("");
+    expect(result.textFiles).toEqual([{ name: "data.txt", content: "hello world" }]);
+  });
+
+  it("extracts two file blocks in order", () => {
+    const result = extractTextFiles('<file path="a.ts">\ncontent a\n</file>\n\n<file path="b.ts">\ncontent b\n</file>\n\nsummary');
+    expect(result.cleaned).toBe("summary");
+    expect(result.textFiles).toEqual([
+      { name: "a.ts", content: "content a" },
+      { name: "b.ts", content: "content b" },
+    ]);
+  });
+});

--- a/tests/queued-message.test.ts
+++ b/tests/queued-message.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildQueuedUserMessage, type QueuedText } from "@/hooks/message-ordering";
+
+const PASTE_SENT_TEXT = '<file path="paste.ts">\nconst x = 1\n</file>\n\nreview this';
+
+describe("buildQueuedUserMessage", () => {
+  it("returns matched entry when queue contains matching apiText", () => {
+    const queued: QueuedText[] = [
+      {
+        text: "review this",
+        apiText: PASTE_SENT_TEXT,
+        textFiles: [{ name: "paste.ts", content: "const x = 1" }],
+      },
+    ];
+    const result = buildQueuedUserMessage(PASTE_SENT_TEXT, queued, "user-queued-1", 1000);
+    expect(result.matchedIndex).toBe(0);
+    expect(result.message.content).toBe("review this");
+    expect(result.message.textFiles).toEqual([{ name: "paste.ts", content: "const x = 1" }]);
+    expect(result.message.images).toBeUndefined();
+    expect(result.message.documents).toBeUndefined();
+  });
+
+  it("reconstructs textFiles from sentText when queue is empty (ref cleared)", () => {
+    const result = buildQueuedUserMessage(PASTE_SENT_TEXT, [], "user-queued-2", 2000);
+    expect(result.matchedIndex).toBe(-1);
+    expect(result.message.content).toBe("review this");
+    expect(result.message.textFiles).toEqual([{ name: "paste.ts", content: "const x = 1" }]);
+  });
+
+  it("recovers images from matched entry", () => {
+    const queued: QueuedText[] = [
+      {
+        text: "review this",
+        apiText: PASTE_SENT_TEXT,
+        textFiles: [{ name: "paste.ts", content: "const x = 1" }],
+        images: [{ mediaType: "image/png" as const, data: "abc" }],
+        documents: [{ mediaType: "application/pdf" as const, data: "pdf content", name: "doc.pdf" }],
+      },
+    ];
+    const result = buildQueuedUserMessage(PASTE_SENT_TEXT, queued, "user-queued-3", 3000);
+    expect(result.matchedIndex).toBe(0);
+    expect(result.message.images).toEqual([{ mediaType: "image/png", data: "abc" }]);
+    expect(result.message.documents).toEqual([{ mediaType: "application/pdf", data: "pdf content", name: "doc.pdf" }]);
+    expect(result.message.textFiles).toEqual([{ name: "paste.ts", content: "const x = 1" }]);
+  });
+
+  it("regression: message.content never contains <file path= substring", () => {
+    const result = buildQueuedUserMessage(PASTE_SENT_TEXT, [], "user-queued-4", 4000);
+    expect(result.message.content).not.toContain("<file path=");
+  });
+
+  it("handles sentText without any file blocks", () => {
+    const queued: QueuedText[] = [{ text: "hello", apiText: "hello" }];
+    const result = buildQueuedUserMessage("hello", queued, "user-queued-5", 5000);
+    expect(result.matchedIndex).toBe(0);
+    expect(result.message.content).toBe("hello");
+    expect(result.message.textFiles).toBeUndefined();
+  });
+
+  it("fallback to undefined textFiles when sentText has no file blocks and queue is empty", () => {
+    const result = buildQueuedUserMessage("plain text", [], "user-queued-6", 6000);
+    expect(result.matchedIndex).toBe(-1);
+    expect(result.message.content).toBe("plain text");
+    expect(result.message.textFiles).toBeUndefined();
+  });
+});


### PR DESCRIPTION
When a paste message is queued during a run and flushes after the run completes, the optimistic bubble rendered the expanded `<file>` block inline instead of the collapsed paste chip. The match between the server-echoed `sentText` (expanded) and the locally stored display text always failed for paste messages, dropping `textFiles` metadata.

**Fix:** consolidate the file-extraction regex into a shared module, match queue entries exactly on `apiText`, and build the injected bubble with cleaned content + reconstructed `textFiles` so the chip renders immediately and dedups with the transcript on reload.

**Acceptance Criteria:**
- [x] A paste message queued during a run renders as a collapsed paste chip (file icon, name, line count) after it flushes, in PTY mode, identical to a non-queued paste send.
- [x] The flushed bubble content never contains the literal file marker text; the expanded file block is not shown inline.
- [x] No duplicate user bubble appears for a flushed queued paste message after the transcript reloads.
- [x] A queued message combining a paste with an image or document recovers all attachments on flush.
- [x] The file extractor lives in one shared module consumed by both the transcript parser and the optimistic-injection path; server transcript parsing behaviour is unchanged.
- [x] Regression tests added: paste-detect for the shared extractor and queued-message for the bubble builder, plus the dedup and textFiles-survival cases in message-ordering.
- [x] Existing tests, the tests typecheck, and the 80% coverage gate all pass.

**Deviations from plan:** none

**Review:** code-reviewer PASS (round 1/4, no findings). Completeness: COMPLETE.