### PR TITLE
fix(sessions): show only usage icon on all-sessions header view

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -4,7 +4,7 @@ import { usePageHeader } from "@/components/app-shell";
 import { SessionList } from "@/components/session-list";
 
 export default function HomePage() {
-  usePageHeader("Cockpit");
+  usePageHeader("Cockpit", { usageOnly: true });
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto">

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -11,6 +11,7 @@ import { TodoIndicator } from "@/components/todo-indicator";
 import { Button } from "@/components/ui/button";
 import { UsageButton } from "@/components/usage-modal";
 import { WebSocketProvider } from "@/hooks/use-websocket";
+import { headerActionsVisibility } from "@/lib/header-actions";
 import type { BackgroundTask, InitData, TodoItem } from "@/types";
 
 export interface SidebarSectionConfig {
@@ -26,6 +27,7 @@ interface HeaderConfig {
   title: string;
   onRename?: (name: string) => void;
   hideActions?: boolean;
+  usageOnly?: boolean;
 }
 
 export interface TabActions {
@@ -83,12 +85,13 @@ export function useShell() {
   return useContext(ShellContext);
 }
 
-export function usePageHeader(title: string, options?: { hideActions?: boolean }) {
+export function usePageHeader(title: string, options?: { hideActions?: boolean; usageOnly?: boolean }) {
   const { setHeader } = useShell();
   const hideActions = options?.hideActions;
+  const usageOnly = options?.usageOnly;
   useEffect(() => {
-    setHeader({ title, hideActions });
-  }, [title, hideActions, setHeader]);
+    setHeader({ title, hideActions, usageOnly });
+  }, [title, hideActions, usageOnly, setHeader]);
 }
 
 export function useShellCwd(cwd: string | undefined) {
@@ -254,6 +257,8 @@ export function AppShell({ children }: { children: ReactNode }) {
     return () => window.removeEventListener("keydown", handler);
   }, [toggleSidebar]);
 
+  const actions = headerActionsVisibility(header);
+
   return (
     <AuthGuard>
       <WebSocketProvider>
@@ -291,13 +296,17 @@ export function AppShell({ children }: { children: ReactNode }) {
                   <Image src="/icon-192.png" alt="" width={22} height={22} className="shrink-0 dark:invert" />
                   <EditableTitle title={header.title} onRename={header.onRename} />
                 </div>
-                {!header.hideActions && (
+                {(actions.showSessionActions || actions.showUsage) && (
                   <div className="flex items-center gap-2 shrink-0 ml-auto">
-                    {cwd && <NewTerminalButton cwd={cwd} />}
-                    <SearchButton />
-                    {cwd && <TodoIndicator todos={todos} />}
-                    {cwd && <BackgroundTasksButton tasks={backgroundTasks} />}
-                    <UsageButton />
+                    {actions.showSessionActions && (
+                      <>
+                        {cwd && <NewTerminalButton cwd={cwd} />}
+                        <SearchButton />
+                        {cwd && <TodoIndicator todos={todos} />}
+                        {cwd && <BackgroundTasksButton tasks={backgroundTasks} />}
+                      </>
+                    )}
+                    {actions.showUsage && <UsageButton />}
                   </div>
                 )}
               </header>

--- a/src/lib/header-actions.ts
+++ b/src/lib/header-actions.ts
@@ -1,0 +1,17 @@
+export interface HeaderActionsConfig {
+  hideActions?: boolean;
+  usageOnly?: boolean;
+}
+
+export interface HeaderActionsVisibility {
+  /** session-scoped controls: New Terminal, Search, Todo, Background Tasks */
+  showSessionActions: boolean;
+  /** the account Usage button */
+  showUsage: boolean;
+}
+
+export function headerActionsVisibility(config: HeaderActionsConfig): HeaderActionsVisibility {
+  if (config.hideActions) return { showSessionActions: false, showUsage: false };
+  if (config.usageOnly) return { showSessionActions: false, showUsage: true };
+  return { showSessionActions: true, showUsage: true };
+}

--- a/src/lib/header-actions.ts
+++ b/src/lib/header-actions.ts
@@ -11,6 +11,7 @@ export interface HeaderActionsVisibility {
 }
 
 export function headerActionsVisibility(config: HeaderActionsConfig): HeaderActionsVisibility {
+  if (!config) return { showSessionActions: false, showUsage: false };
   if (config.hideActions) return { showSessionActions: false, showUsage: false };
   if (config.usageOnly) return { showSessionActions: false, showUsage: true };
   return { showSessionActions: true, showUsage: true };

--- a/tests/header-actions.test.ts
+++ b/tests/header-actions.test.ts
@@ -23,6 +23,13 @@ describe("headerActionsVisibility", () => {
     });
   });
 
+  it("undefined config -> nothing shows (guard)", () => {
+    expect(headerActionsVisibility(undefined as any)).toEqual({
+      showSessionActions: false,
+      showUsage: false,
+    });
+  });
+
   it("hideActions overrides usageOnly", () => {
     expect(headerActionsVisibility({ hideActions: true, usageOnly: true })).toEqual({
       showSessionActions: false,

--- a/tests/header-actions.test.ts
+++ b/tests/header-actions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { headerActionsVisibility } from "@/lib/header-actions";
+
+describe("headerActionsVisibility", () => {
+  it("hideActions: true -> nothing shows", () => {
+    expect(headerActionsVisibility({ hideActions: true })).toEqual({
+      showSessionActions: false,
+      showUsage: false,
+    });
+  });
+
+  it("usageOnly: true -> only usage shows", () => {
+    expect(headerActionsVisibility({ usageOnly: true })).toEqual({
+      showSessionActions: false,
+      showUsage: true,
+    });
+  });
+
+  it("neither flag -> everything shows", () => {
+    expect(headerActionsVisibility({})).toEqual({
+      showSessionActions: true,
+      showUsage: true,
+    });
+  });
+
+  it("hideActions overrides usageOnly", () => {
+    expect(headerActionsVisibility({ hideActions: true, usageOnly: true })).toEqual({
+      showSessionActions: false,
+      showUsage: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The all-sessions view (home, route /) was showing the full header action bar — New Terminal, Search, Todo, Background Tasks, and Usage — carried over from the last viewed session via a stale `cwd`. This fix adds a `usageOnly` header mode so the home page shows only the Account usage button.

## Acceptance Criteria

- [x] On the all-sessions view (home, route /), the header action area shows only the Account usage button and none of New Terminal, Search, Todo, or Background Tasks, verified after first opening a session and navigating back.
- [x] The session view header is unchanged: it still shows the session action icons plus the usage button.
- [x] Every page that previously set hideActions to true still shows no action buttons; the usage button does not newly appear on them.
- [x] A new pure helper decides the three header-action states and is unit-tested across all branches, including the hideActions-over-usageOnly precedence, in a new test file.
- [x] The home view header is exercised in a browser DOM check asserting only the usage button is present.
- [x] Build, lint, typecheck over tests, and vitest with coverage all pass.

## Deviations from plan

None.

## Review

Code review: PASS (round 1, no Critical/High findings, one Medium fix applied).
UI review: PASS (round 1, all UI criteria confirmed in browser).
Completeness: COMPLETE (all acceptance criteria have implementing code).

Closes ALE-614.