### PR TITLE
fix(jobs): reorganise job card so title spans full width (ALE-621)

### DIFF
--- a/src/app/(app)/jobs/page.tsx
+++ b/src/app/(app)/jobs/page.tsx
@@ -130,12 +130,14 @@ function JobCard({
   return (
     <Card className="cursor-pointer hover:bg-accent/50 transition-colors" onClick={() => onClick(job.id)}>
       <CardContent className="p-4">
+        {/* Row 1: title spans the full card width; status badge trails at the right */}
+        <div className="flex items-center gap-2 mb-2">
+          <span className="font-medium text-sm truncate flex-1 min-w-0">{job.name}</span>
+          {statusBadge(job)}
+        </div>
+        {/* Row 2: schedule/next/last-run metadata on the left, actions on the right */}
         <div className="flex items-center gap-3">
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <span className="font-medium text-sm truncate">{job.name}</span>
-              {statusBadge(job)}
-            </div>
             <p className="text-xs text-muted-foreground">{describeAllSchedules(getJobSchedules(job))}</p>
             <p className="text-xs text-muted-foreground mt-0.5">Next: {formatNextRun(job)}</p>
             {lastRunInfo(job) && <p className="text-xs mt-0.5">{lastRunInfo(job)}</p>}


### PR DESCRIPTION
## Summary

Reorganise the job card so the title spans the full card width, with the status badge trailing at the right end of the title row. Run/Duplicate/Delete buttons move to a second row beneath the metadata.

## Acceptance Criteria

- [x] The job title renders on its own row at the top of the card, spanning the full width of the card content area.
- [x] With a long job name the title uses the full available width and truncates with an ellipsis only at the card edge, no longer constrained by the action-button column.
- [x] The status badge remains visible at the right end of the title row.
- [x] The schedule text, the Next run text, and the last-run status line remain below the title.
- [x] The Run now, Duplicate, and Delete buttons remain functional, sit on the row below the title, and do not trigger card navigation when clicked.
- [x] Run now still shows the spinner while a trigger is in flight.
- [x] Clicking the card outside the buttons still opens the job detail page.
- [x] The layout holds at mobile width with no horizontal overflow (verified by ui-reviewer at 393px and 1280px).
- [x] The change is confined to the JobCard component; no job behaviour or data changes.

## Deviations from plan

None.

## Review

- **Completeness:** COMPLETE (round 1)
- **Code review:** PASS (round 1)
- **UI review:** PASS (round 1)

Closes ALE-621