### PR TITLE
fix(jobs): show Running indicator on manual trigger and rename Active to Enabled

### DIFF
--- a/src/app/(app)/jobs/[id]/page.tsx
+++ b/src/app/(app)/jobs/[id]/page.tsx
@@ -150,7 +150,7 @@ export default function JobDetailPage() {
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
               <h2 className="font-semibold truncate">{job.name}</h2>
-              {job.enabled ? <Badge variant="default">Active</Badge> : <Badge variant="secondary">Disabled</Badge>}
+              {job.enabled ? <Badge variant="default">Enabled</Badge> : <Badge variant="secondary">Disabled</Badge>}
             </div>
             <p className="text-xs text-muted-foreground">{describeAllSchedules(getJobSchedules(job))}</p>
           </div>

--- a/src/app/(app)/jobs/page.tsx
+++ b/src/app/(app)/jobs/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useJobs } from "@/hooks/use-jobs";
+import { type JobDisplayStatus, jobDisplayStatus } from "@/lib/job-display";
 import { describeAllSchedules, getJobSchedules, getNextRunTimeAny } from "@/server/cron-utils";
 import type { ScheduledJob } from "@/types";
 
@@ -18,15 +19,11 @@ type JobWithStatus = ScheduledJob & {
   lastRunError?: string;
 };
 
-function statusBadge(job: JobWithStatus) {
-  if (!job.enabled) return <Badge variant="secondary">Disabled</Badge>;
-  if (job.lastRunStatus === "failure" || job.lastRunStatus === "timeout") {
-    return <Badge variant="destructive">Failed</Badge>;
-  }
-  if (job.lastRunStatus === "running") {
-    return <Badge variant="default">Running</Badge>;
-  }
-  return <Badge variant="default">Active</Badge>;
+function statusBadge(status: JobDisplayStatus) {
+  if (status === "running") return <Badge variant="default">Running</Badge>;
+  if (status === "disabled") return <Badge variant="secondary">Disabled</Badge>;
+  if (status === "failed") return <Badge variant="destructive">Failed</Badge>;
+  return <Badge variant="default">Enabled</Badge>;
 }
 
 function lastRunInfo(job: JobWithStatus) {
@@ -48,15 +45,16 @@ function lastRunInfo(job: JobWithStatus) {
       </span>
     );
   }
-  if (job.lastRunStatus === "running") {
-    return (
-      <span className="flex items-center gap-1">
-        <Loader2 className="h-3 w-3 animate-spin" />
-        Running
-      </span>
-    );
-  }
   return null;
+}
+
+function runningIndicator() {
+  return (
+    <span className="flex items-center gap-1">
+      <Loader2 className="h-3 w-3 animate-spin" />
+      Running
+    </span>
+  );
 }
 
 function timeAgo(ts: number): string {
@@ -127,20 +125,26 @@ function JobCard({
   onDelete: (e: React.MouseEvent, id: string) => void;
   onClick: (id: string) => void;
 }) {
+  const status = jobDisplayStatus(job, triggeringJobs.has(job.id));
+  const running = status === "running";
   return (
     <Card className="cursor-pointer hover:bg-accent/50 transition-colors" onClick={() => onClick(job.id)}>
       <CardContent className="p-4">
         {/* Row 1: title spans the full card width; status badge trails at the right */}
         <div className="flex items-center gap-2 mb-2">
           <span className="font-medium text-sm truncate flex-1 min-w-0">{job.name}</span>
-          {statusBadge(job)}
+          {statusBadge(status)}
         </div>
         {/* Row 2: schedule/next/last-run metadata on the left, actions on the right */}
         <div className="flex items-center gap-3">
           <div className="flex-1 min-w-0">
             <p className="text-xs text-muted-foreground">{describeAllSchedules(getJobSchedules(job))}</p>
             <p className="text-xs text-muted-foreground mt-0.5">Next: {formatNextRun(job)}</p>
-            {lastRunInfo(job) && <p className="text-xs mt-0.5">{lastRunInfo(job)}</p>}
+            {running ? (
+              <p className="text-xs mt-0.5">{runningIndicator()}</p>
+            ) : (
+              lastRunInfo(job) && <p className="text-xs mt-0.5">{lastRunInfo(job)}</p>
+            )}
           </div>
           <div className="flex items-center gap-1 shrink-0">
             <Button

--- a/src/lib/job-display.ts
+++ b/src/lib/job-display.ts
@@ -1,0 +1,16 @@
+import type { ScheduledJob } from "@/types";
+
+export type JobDisplayStatus = "running" | "disabled" | "failed" | "enabled";
+
+// lastRunStatus is typed `string | undefined` to match JobWithStatus (page.tsx:16),
+// whose lastRunStatus is widened to string by the API enrichment; using JobRunStatus
+// here would force a cast at the call site.
+// Precedence: running is checked FIRST (a triggering or server-running job reads
+// "Running" even if disabled). This INTENTIONALLY differs from the current
+// statusBadge, which checks !enabled first.
+export function jobDisplayStatus(job: Pick<ScheduledJob, "enabled"> & { lastRunStatus?: string }, isTriggering: boolean): JobDisplayStatus {
+  if (isTriggering || job.lastRunStatus === "running") return "running";
+  if (!job.enabled) return "disabled";
+  if (job.lastRunStatus === "failure" || job.lastRunStatus === "timeout") return "failed";
+  return "enabled";
+}

--- a/tests/job-display.test.ts
+++ b/tests/job-display.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { jobDisplayStatus } from "@/lib/job-display";
+
+describe("jobDisplayStatus", () => {
+  it("returns enabled for an enabled, not-triggering job with no lastRunStatus", () => {
+    expect(jobDisplayStatus({ enabled: true }, false)).toBe("enabled");
+  });
+
+  it("returns enabled for an enabled, not-triggering job that succeeded", () => {
+    expect(jobDisplayStatus({ enabled: true, lastRunStatus: "success" }, false)).toBe("enabled");
+  });
+
+  it("returns failed for an enabled job that last failed", () => {
+    expect(jobDisplayStatus({ enabled: true, lastRunStatus: "failure" }, false)).toBe("failed");
+  });
+
+  it("returns failed for an enabled job that timed out", () => {
+    expect(jobDisplayStatus({ enabled: true, lastRunStatus: "timeout" }, false)).toBe("failed");
+  });
+
+  it("returns running for an enabled server-running job", () => {
+    expect(jobDisplayStatus({ enabled: true, lastRunStatus: "running" }, false)).toBe("running");
+  });
+
+  it("returns running when isTriggering is true even with no lastRunStatus (never-run)", () => {
+    expect(jobDisplayStatus({ enabled: true }, true)).toBe("running");
+  });
+
+  it("returns disabled when job is not enabled and not triggering", () => {
+    expect(jobDisplayStatus({ enabled: false }, false)).toBe("disabled");
+  });
+
+  it("returns running when disabled but triggering (precedence)", () => {
+    expect(jobDisplayStatus({ enabled: false }, true)).toBe("running");
+  });
+
+  it("returns running when disabled but lastRunStatus is running", () => {
+    expect(jobDisplayStatus({ enabled: false, lastRunStatus: "running" }, false)).toBe("running");
+  });
+});


### PR DESCRIPTION
Two consistency fixes to the Scheduled Jobs card:

**Changes:**
- Rename enabled-job status badge from "Active" to "Enabled" (pairs with "Disabled")
- Show Running badge + spinner/"Running" line (below "Next:") on manual "Run now" trigger, matching the existing scheduler-fired running indicator
- New `jobDisplayStatus()` pure function with correct precedence: running overrides disabled
- Detail page badge text: "Active" → "Enabled"

**Acceptance Criteria:**
- [x] The enabled-job status badge on the jobs list card reads Enabled, not Active.
- [x] The job detail page status badge reads Enabled, not Active, for an enabled job.
- [x] Clicking Run now on a job card shows the Running badge and a spinner with the word Running on the line below the Next line, for the duration of the run.
- [x] The Running indicator appears even for a job that has never run before.
- [x] A server-running job shows exactly one Running line on the card (no duplicate).
- [x] When the run finishes, the card returns to the Enabled or Failed badge and shows the latest run outcome line.
- [x] A disabled job that is not running still shows the Disabled badge.
- [x] jobDisplayStatus has unit tests covering every branch and the suite passes with coverage at or above the 80 percent gate.
- [x] No existing test or behaviour depending on the word Active in the jobs UI is broken.

**Deviations from plan:** none

**Review:** completeness: COMPLETE (1 round), code: PASS (1 round), UI: PASS (1 round, only LOW pre-existing findings)
