### PR TITLE
feat(chat): fuzzy search for skills and agents in slash/mention menus

### DIFF
--- a/src/components/mention-menu.tsx
+++ b/src/components/mention-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { fuzzyMatch } from "@/lib/fuzzy-search";
 import { pathBasename, pathDirname } from "@/lib/path";
 import type { InitAgentInfo } from "@/types";
 
@@ -69,8 +70,6 @@ export function MentionMenu({ query, cwd, selectedIndex, onSelect, onItemsChange
     };
   }, [query, cwd]);
 
-  const lowerQuery = query.toLowerCase();
-
   const allAgents = useMemo(() => {
     if (initAgents && initAgents.length > 0) {
       return initAgents.map((a) => ({ name: a.name, description: a.description }));
@@ -86,10 +85,18 @@ export function MentionMenu({ query, cwd, selectedIndex, onSelect, onItemsChange
 
   const matchedAgents: MentionItem[] = useMemo(
     () =>
-      allAgents
-        .filter((a) => a.name.toLowerCase().includes(lowerQuery))
-        .map((a) => ({ value: a.name, label: a.name, description: a.description, kind: "agent" as const })),
-    [lowerQuery, allAgents],
+      fuzzyMatch(
+        query,
+        allAgents,
+        (a) => a.name,
+        (a) => a.description,
+      ).map((a) => ({
+        value: a.name,
+        label: a.name,
+        description: a.description,
+        kind: "agent" as const,
+      })),
+    [query, allAgents],
   );
 
   const fileItems: MentionItem[] = useMemo(() => files.map((f) => ({ value: f, label: f, kind: "file" as const })), [files]);

--- a/src/components/slash-command-menu.tsx
+++ b/src/components/slash-command-menu.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { type SlashCommand, slashCommands } from "@/lib/commands";
+import { fuzzyMatch } from "@/lib/fuzzy-search";
 
 // Commands handled client-side by Cockpit, always included
 const cockpitCommands: SlashCommand[] = [
@@ -88,7 +89,12 @@ export function SlashCommandMenu({ query, selectedIndex, onSelect, cwd, onItemsC
     }
   }
 
-  const filtered = allCommands.filter((cmd) => cmd.command.startsWith("/" + query));
+  const filtered = fuzzyMatch(
+    query,
+    allCommands,
+    (cmd) => cmd.command.slice(1),
+    (cmd) => cmd.description,
+  );
 
   useEffect(() => {
     onItemsChange?.(filtered);

--- a/src/lib/fuzzy-search.ts
+++ b/src/lib/fuzzy-search.ts
@@ -1,0 +1,113 @@
+/**
+ * Character-subsequence match scoring for a single field.
+ *
+ * +1 per matched character
+ * +2 for each character that immediately follows another matched character
+ *    in the target string (consecutive runs). Runs restart after a
+ *    non-matching character. The first character of each run gets this bonus.
+ * +3 if the first matched character is at a word boundary
+ *    (after `-`, `_`, uppercase transition, or start of string)
+ * +5 if the first matched character is at index 0 of the field
+ *
+ * Returns 0 when no subsequence match is found.
+ */
+function scoreField(query: string, target: string): number {
+  if (query.length === 0) return 0;
+
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  let qi = 0;
+  let score = 0;
+  let prevMatched = false;
+
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      const isFirstChar = qi === 0;
+      const charBefore = ti > 0 ? target[ti - 1] : "";
+      const isWordBoundary =
+        ti === 0 ||
+        charBefore === "-" ||
+        charBefore === "_" ||
+        (charBefore >= "a" && charBefore <= "z" && target[ti] >= "A" && target[ti] <= "Z");
+
+      score += 1;
+      if (prevMatched) score += 2;
+      if (isFirstChar && isWordBoundary) score += 3;
+      if (ti === 0) score += 5;
+
+      prevMatched = true;
+      qi++;
+    } else {
+      prevMatched = false;
+    }
+  }
+
+  // Not all query characters matched — no subsequence found
+  if (qi < q.length) return 0;
+
+  return score;
+}
+
+interface ScoredCandidate<T> {
+  candidate: T;
+  nameScore: number;
+  descriptionScore: number;
+  index: number;
+}
+
+/**
+ * Filter and rank candidates by character-subsequence match.
+ *
+ * Candidates with a name match (nameScore > 0) appear first, sorted by
+ * nameScore descending. Candidates matching only in the description appear
+ * after, sorted by descriptionScore descending. Ties preserve source order.
+ *
+ * Empty query returns all candidates in source order (no filtering).
+ */
+export function fuzzyMatch<T>(
+  query: string,
+  candidates: readonly T[],
+  keyFn: (c: T) => string,
+  descriptionFn?: (c: T) => string | undefined,
+): T[] {
+  if (query.length === 0) return [...candidates];
+
+  const scored: ScoredCandidate<T>[] = [];
+
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i];
+    const nameScore = scoreField(query, keyFn(candidate));
+
+    let descriptionScore = 0;
+    if (descriptionFn) {
+      const desc = descriptionFn(candidate);
+      if (desc && desc.length > 0) {
+        descriptionScore = scoreField(query, desc);
+      }
+    }
+
+    if (nameScore > 0 || descriptionScore > 0) {
+      scored.push({ candidate, nameScore, descriptionScore, index: i });
+    }
+  }
+
+  // Segregated ranking: name matches first, then description-only matches
+  scored.sort((a, b) => {
+    // Both have name scores — sort by name score desc, then index for stability
+    if (a.nameScore > 0 && b.nameScore > 0) {
+      const diff = b.nameScore - a.nameScore;
+      if (diff !== 0) return diff;
+      return a.index - b.index;
+    }
+    // Only A has a name score — A comes first
+    if (a.nameScore > 0) return -1;
+    // Only B has a name score — B comes first
+    if (b.nameScore > 0) return 1;
+    // Neither has a name score — sort by description score desc, then index
+    const diff = b.descriptionScore - a.descriptionScore;
+    if (diff !== 0) return diff;
+    return a.index - b.index;
+  });
+
+  return scored.map((s) => s.candidate);
+}

--- a/tests/fuzzy-search.test.ts
+++ b/tests/fuzzy-search.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { fuzzyMatch } from "@/lib/fuzzy-search";
+
+interface Named {
+  name: string;
+  description?: string;
+}
+
+describe("fuzzyMatch", () => {
+  it("matches subsequence across separator", () => {
+    const candidates: Named[] = [{ name: "myorg-review" }];
+    const result = fuzzyMatch("review", candidates, (c) => c.name);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("myorg-review");
+  });
+
+  it("exact prefix match scores higher than subsequence across separator", () => {
+    const candidates: Named[] = [{ name: "myorg-review" }, { name: "review" }];
+    const result = fuzzyMatch("review", candidates, (c) => c.name);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("review");
+  });
+
+  it("match at start of name ranks higher than match later in name", () => {
+    const candidates: Named[] = [{ name: "preview" }, { name: "review" }];
+    const result = fuzzyMatch("rev", candidates, (c) => c.name);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("review");
+  });
+
+  it("matches non-contiguous subsequence", () => {
+    const candidates: Named[] = [{ name: "review" }];
+    const result = fuzzyMatch("rvw", candidates, (c) => c.name);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("review");
+  });
+
+  it("returns empty array when no match", () => {
+    const candidates: Named[] = [{ name: "review" }];
+    const result = fuzzyMatch("xyz", candidates, (c) => c.name);
+    expect(result).toHaveLength(0);
+  });
+
+  it("empty query returns all candidates in original order", () => {
+    const candidates: Named[] = [{ name: "a" }, { name: "b" }];
+    const result = fuzzyMatch("", candidates, (c) => c.name);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("a");
+    expect(result[1].name).toBe("b");
+  });
+
+  it("matches via description when name does not match", () => {
+    const candidates: Named[] = [{ name: "foo", description: "review things" }];
+    const result = fuzzyMatch(
+      "review",
+      candidates,
+      (c) => c.name,
+      (c) => c.description,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("foo");
+  });
+
+  it("name match ranked above description-only match", () => {
+    const candidates: Named[] = [
+      { name: "foo", description: "review things" },
+      { name: "rev", description: "something else" },
+    ];
+    const result = fuzzyMatch(
+      "rev",
+      candidates,
+      (c) => c.name,
+      (c) => c.description,
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("rev");
+    expect(result[1].name).toBe("foo");
+  });
+
+  it("is case-insensitive", () => {
+    const candidates: Named[] = [{ name: "myorg-review" }];
+    const result = fuzzyMatch("REVIEW", candidates, (c) => c.name);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("myorg-review");
+  });
+
+  it("handles special regex characters literally", () => {
+    const candidates: Named[] = [{ name: "myorg.review" }];
+    const result = fuzzyMatch(".", candidates, (c) => c.name);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("myorg.review");
+  });
+
+  it("preserves source order on equal scores (stable sort)", () => {
+    const candidates: Named[] = [{ name: "aba" }, { name: "aca" }];
+    // Both "aba" and "aca" match query "aa" with identical scores
+    const result = fuzzyMatch("aa", candidates, (c) => c.name);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("aba");
+    expect(result[1].name).toBe("aca");
+  });
+
+  it("returns empty array for empty candidate list", () => {
+    const candidates: Named[] = [];
+    const result = fuzzyMatch("review", candidates, (c) => c.name);
+    expect(result).toHaveLength(0);
+  });
+
+  it("query longer than candidate name returns no match", () => {
+    const candidates: Named[] = [{ name: "abc" }];
+    const result = fuzzyMatch("abcd", candidates, (c) => c.name);
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces prefix matching (`/`) and substring matching (`@`) with character-subsequence fuzzy matching that scores results by relevance. Plugin-namespaced items like `myorg-review` now match queries like `review`.

The fuzzy match algorithm:
- +1 per matched character
- +2 per consecutive match in a run
- +3 at word boundary
- +5 at name start
- Name matches rank above description-only matches
- Empty query returns all items (preserves current behaviour)

## Acceptance Criteria

- [x] Typing /review matches a skill named myorg-review in the slash command menu
- [x] Typing /review ranks the exact skill named review above myorg-review when both exist
- [x] Typing @review matches an agent named myorg-review-agent in the mention menu
- [x] Typing @foo with no matches hides the dropdown
- [x] Typing / with no query shows all commands and skills
- [x] File search in the @ menu is unchanged
- [x] All existing keyboard navigation works (unchanged code paths)
- [x] Both light and dark themes render identically (no style changes)
- [x] The fuzzy matching logic is covered by unit tests with the cases listed above
- [x] npm run build and npx vitest run pass with 80%+ coverage

## Deviations from plan

None.

## Review

- **Completeness:** all criteria met (keyboard navigation not exercised in a standalone test, but code path is unchanged). Single round.
- **Code review:** PASS (round 1/4). No Critical/High findings.
- **UI review:** PASS (round 1/4). No findings.
