### PR TITLE
fix(session-settings): resolve provider dropdown to current session's provider

### DIFF
--- a/src/components/input-area.tsx
+++ b/src/components/input-area.tsx
@@ -43,6 +43,7 @@ import {
   findModelById,
   type ModelAlias,
   type ModelEntry,
+  resolveProviderId,
   versionsForAlias,
 } from "@/lib/models";
 import { detectLanguage, extensionForLabel, shouldCollapsePaste } from "@/lib/paste-detect";
@@ -861,6 +862,7 @@ export function InputArea({
                             </div>
                             <select
                               value={viewProvider}
+                              data-testid="provider-select"
                               onChange={(e) => setViewProvider(e.target.value)}
                               className="rounded border border-input bg-background px-2 py-1 text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                             >
@@ -1225,8 +1227,7 @@ export function InputArea({
                   if (!v) {
                     const p = parseCurrentModel(currentModel, currentContextSize);
                     if (!p.alias) {
-                      const prov = providers?.find((x) => x.models.some((m) => m.modelId === currentModel));
-                      setViewProvider(prov?.id ?? "anthropic");
+                      setViewProvider(resolveProviderId(currentModel, providers));
                     } else {
                       setViewProvider("anthropic");
                     }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -146,3 +146,10 @@ export function splitLegacyModel(stored: string | undefined | null): {
     contextSize: hasOneM ? "1m" : "200k",
   };
 }
+
+export function resolveProviderId(currentModel: string, providers: { id: string; models: { modelId: string }[] }[] | undefined): string {
+  if (!providers) return "anthropic";
+  const stripped = currentModel.replace(/\[.*\]$/, "");
+  const provider = providers.find((p) => p.models.some((m) => m.modelId === stripped || `${p.id}:${m.modelId}` === stripped));
+  return provider?.id ?? "anthropic";
+}

--- a/tests/integration/model-selector.spec.ts
+++ b/tests/integration/model-selector.spec.ts
@@ -54,12 +54,39 @@ test("session-settings dialog opens for a custom model with no contextSizes", as
     await page.getByTestId("btn-session-settings").click();
 
     // The dialog header must render. With the bug, the error boundary replaced
-    // the whole page with "This page couldn't load".
+    // the whole page with "This page couldn’t load".
     await expect(page.getByRole("heading", { name: "Session settings" })).toBeVisible();
     await expect(page.getByText("This page couldn’t load")).toHaveCount(0);
 
-    // No uncaught "reading 'length'" (or any) error should have fired.
+    // No uncaught "reading ‘length’" (or any) error should have fired.
     expect(pageErrors, `unexpected page errors: ${pageErrors.join(" | ")}`).toHaveLength(0);
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test("provider dropdown defaults to the current custom provider", async ({ page, harness }) => {
+  const workDir = mkdtempSync(path.join(tmpdir(), "cockpit-it-provdflt-"));
+  mkdirSync(path.join(workDir, ".git"), { recursive: true });
+
+  try {
+    // Session with a model that matches the harness mock provider’s modelId.
+    const createRes = await page.request.post(`${harness.cockpitUrl}/api/sessions`, {
+      data: { cwd: workDir, runtime: "pty", model: "mock:claude-sonnet-4-6" },
+    });
+    expect(createRes.ok()).toBe(true);
+    const { sessionId } = await createRes.json();
+
+    await page.goto(`${harness.cockpitUrl}/sessions/${sessionId}?cwd=${encodeURIComponent(workDir)}`);
+    await expect(page.getByTestId("message-input")).toBeVisible();
+    await page.waitForTimeout(2000);
+
+    // Open the settings dialog.
+    await page.getByTestId("btn-session-settings").click();
+    await expect(page.getByRole("heading", { name: "Session settings" })).toBeVisible();
+
+    // The provider dropdown should show "mock" (the custom provider), not "anthropic".
+    await expect(page.locator('[data-testid="provider-select"]')).toHaveValue("mock");
   } finally {
     rmSync(workDir, { recursive: true, force: true });
   }

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -7,6 +7,7 @@ import {
   MODELS,
   recommendedEffort,
   resolveModel,
+  resolveProviderId,
   versionsForAlias,
 } from "@/lib/models";
 
@@ -287,5 +288,36 @@ describe("coerceEffort", () => {
 
   it("returns recommended for opus 4.6 when level not allowed", () => {
     expect(coerceEffort("xhigh", opus46)).toBe("high");
+  });
+});
+
+describe("resolveProviderId", () => {
+  const providers = [
+    { id: "anthropic", models: [{ modelId: "claude-sonnet-4-6" }] },
+    { id: "custom", models: [{ modelId: "some-model" }] },
+  ];
+
+  it("resolves prefixed model to custom provider", () => {
+    expect(resolveProviderId("custom:some-model", providers)).toBe("custom");
+  });
+
+  it("resolves prefixed model with suffix to custom provider", () => {
+    expect(resolveProviderId("custom:some-model[1m]", providers)).toBe("custom");
+  });
+
+  it("resolves bare anthropic model to anthropic", () => {
+    expect(resolveProviderId("claude-sonnet-4-6", providers)).toBe("anthropic");
+  });
+
+  it("falls back to anthropic for nonexistent model", () => {
+    expect(resolveProviderId("nonexistent", providers)).toBe("anthropic");
+  });
+
+  it("falls back to anthropic when providers is undefined", () => {
+    expect(resolveProviderId("custom:some-model", undefined)).toBe("anthropic");
+  });
+
+  it("falls back to anthropic when providers is empty array", () => {
+    expect(resolveProviderId("custom:some-model", [])).toBe("anthropic");
   });
 });


### PR DESCRIPTION
The session settings provider dropdown always defaulted to Anthropic when a custom provider model was active. The model ID stored as `providerId:modelId` didn't match the bare `modelId` in the provider lookup.

### Changes
- Added `resolveProviderId` to `src/lib/models.ts` — strips context-size suffixes, matches against both bare and prefixed model ID formats
- Replaced inline buggy provider lookup in `input-area.tsx` with `resolveProviderId` call
- Added `data-testid="provider-select"` to the select element for testing
- Unit tests for `resolveProviderId` in `tests/models.test.ts`
- Integration test in `tests/integration/model-selector.spec.ts`

### Acceptance Criteria
- [x] Opening session settings with a custom-provider model active shows that provider in the dropdown, not Anthropic
- [x] Opening session settings with an Anthropic model active still shows Anthropic (no regression)
- [x] resolveProviderId is exported from lib/models and unit-tested for bare, prefixed, and suffixed model ID formats
- [x] Integration test verifies the select element value is the custom provider after session creation with a custom model

### Deviations from plan
None.

### Review
Code review: PASS (1 round, no Critical/High findings)
UI review: PASS (screenshots attached to issue)
Completeness: COMPLETE (all acceptance criteria met)

Closes ALE-635