### PR TITLE
fix(settings): center content columns with mx-auto on settings pages

### DIFF
--- a/src/app/(app)/settings/appearance/page.tsx
+++ b/src/app/(app)/settings/appearance/page.tsx
@@ -133,7 +133,7 @@ export default function AppearanceSettingsPage() {
         <ArrowLeft className="h-4 w-4 mr-1" />
         Settings
       </Button>
-      <div className="max-w-lg space-y-1">
+      <div className="max-w-lg mx-auto space-y-1" data-testid="settings-content">
         <SettingRow label="Theme">
           <ButtonGroup options={themeOptions} value={theme} onChange={selectTheme} />
         </SettingRow>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -312,7 +312,7 @@ export default function SettingsPage() {
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto p-4 sm:p-6">
-      <div className="max-w-lg space-y-3">
+      <div className="max-w-lg mx-auto space-y-3" data-testid="settings-content">
         <div className="min-h-[104px]">
           {(versionLoading || version) && (
             <VersionCard

--- a/src/app/(app)/settings/providers/[id]/page.tsx
+++ b/src/app/(app)/settings/providers/[id]/page.tsx
@@ -69,7 +69,7 @@ export default function EditProviderPage() {
         <ArrowLeft className="h-4 w-4 mr-1" />
         Settings
       </Button>
-      <div className="max-w-xl flex-1 min-h-0">
+      <div className="max-w-xl mx-auto flex-1 min-h-0" data-testid="settings-content">
         <ProviderForm
           provider={provider}
           isNew={false}

--- a/src/app/(app)/settings/providers/new/page.tsx
+++ b/src/app/(app)/settings/providers/new/page.tsx
@@ -29,7 +29,7 @@ export default function NewProviderPage() {
         <ArrowLeft className="h-4 w-4 mr-1" />
         Settings
       </Button>
-      <div className="max-w-xl flex-1 min-h-0">
+      <div className="max-w-xl mx-auto flex-1 min-h-0" data-testid="settings-content">
         <ProviderForm
           provider={{
             id: "",

--- a/src/app/(app)/settings/providers/page.tsx
+++ b/src/app/(app)/settings/providers/page.tsx
@@ -31,7 +31,7 @@ export default function ProvidersPage() {
         <ArrowLeft className="h-4 w-4 mr-1" />
         Settings
       </Button>
-      <div className="max-w-lg space-y-1">
+      <div className="max-w-lg mx-auto space-y-1" data-testid="settings-content">
         {providers.map((provider) => (
           <button
             key={provider.id}

--- a/src/app/(app)/settings/session/page.tsx
+++ b/src/app/(app)/settings/session/page.tsx
@@ -114,7 +114,7 @@ export default function SessionSettingsPage() {
         <ArrowLeft className="h-4 w-4 mr-1" />
         Settings
       </Button>
-      <div className="max-w-lg space-y-1">
+      <div className="max-w-lg mx-auto space-y-1" data-testid="settings-content">
         <SettingRow label="Model">
           <ButtonGroup
             options={

--- a/tests/integration/settings-width.spec.ts
+++ b/tests/integration/settings-width.spec.ts
@@ -1,0 +1,89 @@
+// Regression: settings content columns must be horizontally centered on
+// desktop, fill available width on mobile, and hold centering in dark theme.
+//
+// Each settings page wraps its content in a max-w-* div that was missing
+// mx-auto, pinning the column to the left. This test asserts the column is
+// centered (left and right gutters equal within 2px) on the five in-scope
+// pages, fills width on mobile, and remains centered in dark theme.
+
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "./fixtures";
+
+async function stubVersionEndpoints(page: Page) {
+  await page.route("**/api/version", async (route) => {
+    await route.fulfill({
+      json: { installed: "2.0.0", latest: "2.0.0", updateCommand: "npm i -g @anthropic-ai/claude-code" },
+    });
+  });
+  await page.route("**/api/version/cockpit", async (route) => {
+    await route.fulfill({
+      json: { installed: "0.4.0", latest: "0.4.0", installMethod: "dev", updateCommand: null },
+    });
+  });
+  await page.route("**/api/version/changelog", async (route) => {
+    await route.fulfill({ json: { releases: [{ version: "1.9.9", items: ["x"] }] } });
+  });
+  await page.route("**/api/version/cockpit/changelog", async (route) => {
+    await route.fulfill({
+      json: {
+        releases: [{ version: "0.4.0", date: "2026-06-01", sections: [{ heading: "Fixes", items: ["y"] }] }],
+        repo: "alexjbarnes/cockpit",
+      },
+    });
+  });
+}
+
+async function assertCentered(col: Locator) {
+  const container = col.locator("xpath=..");
+  const b = await col.boundingBox();
+  const c = await container.boundingBox();
+  expect(b && c).toBeTruthy();
+  const leftGutter = b!.x - c!.x;
+  const rightGutter = c!.x + c!.width - (b!.x + b!.width);
+  expect(Math.abs(leftGutter - rightGutter)).toBeLessThanOrEqual(2);
+  // real gutter exists -> assertion is meaningful
+  expect(c!.width - b!.width).toBeGreaterThan(100);
+}
+
+test.describe("settings page width", () => {
+  const PAGES = ["/settings", "/settings/session", "/settings/appearance", "/settings/providers", "/settings/providers/new"];
+
+  test("desktop centering on all in-scope settings pages", async ({ page, harness }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await stubVersionEndpoints(page);
+
+    for (const path of PAGES) {
+      await page.goto(`${harness.cockpitUrl}${path}`);
+      const col = page.getByTestId("settings-content");
+      await expect(col).toBeVisible();
+      await assertCentered(col);
+    }
+  });
+
+  test("dark theme centering on /settings", async ({ page, harness }) => {
+    await page.addInitScript(() => localStorage.setItem("cockpit-theme", "dark"));
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await stubVersionEndpoints(page);
+
+    await page.goto(`${harness.cockpitUrl}/settings`);
+    const col = page.getByTestId("settings-content");
+    await expect(col).toBeVisible();
+    await assertCentered(col);
+  });
+
+  test("mobile no-regression: column fills available width", async ({ page, harness }) => {
+    await page.setViewportSize({ width: 393, height: 800 });
+    await stubVersionEndpoints(page);
+
+    await page.goto(`${harness.cockpitUrl}/settings`);
+    const col = page.getByTestId("settings-content");
+    await expect(col).toBeVisible();
+    const container = col.locator("xpath=..");
+    const b = await col.boundingBox();
+    const c = await container.boundingBox();
+    expect(b && c).toBeTruthy();
+    // at mobile the column fills the content width; only the container's p-4 padding differs
+    expect(c!.width - b!.width).toBeLessThanOrEqual(40);
+    expect(b!.x).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
Settings content columns were pinned left because their `max-w-lg`/`max-w-xl` wrappers lacked `mx-auto`. This centers them, matching the jobs/[id] page layout.

**Acceptance Criteria:**
- [x] Desktop (1280px): content column centered on main settings, session, appearance, providers list, add-provider pages — left and right gutters equal within 2px
- [x] Edit-provider page (providers/[id]) also receives `mx-auto` (verified manually — excluded from automated spec as it needs a seeded provider)
- [x] Mobile (393px): column fills width, no overflow, no visual change
- [x] Max-width values unchanged — only centering added
- [x] Dark theme centering holds (spec seeds dark theme and asserts centering)
- [x] Playwright integration regression test at `tests/integration/settings-width.spec.ts` covering desktop centering, dark theme, and mobile
- [x] No non-settings page changed

**Deviations from plan:** none

**Review:** Code review: PASS (round 1, no findings). UI review: PASS (round 1, no findings). Completeness: COMPLETE (round 1).