### PR TITLE
Release 0.4.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: next
     schedule:
       interval: weekly
       day: friday
@@ -14,6 +15,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: next
     schedule:
       interval: weekly
       day: friday

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,3 @@ jobs:
   test:
     needs: [verify-tag, typecheck, lint, secrets]
     uses: ./.github/workflows/test.yml
-  socket:
-    needs: [verify-tag, typecheck, lint, secrets]
-    uses: ./.github/workflows/socket.yml
-    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,8 @@ jobs:
     uses: ./.github/workflows/test.yml
   socket:
     needs: [typecheck, lint, secrets]
+    # Scan on PRs and on merges to main only (not on next pushes); socket.yml
+    # further limits PR scans to the first run plus dependency-manifest changes.
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     uses: ./.github/workflows/socket.yml
     secrets: inherit

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -10,22 +10,78 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
+
+      # Gate the scan to keep Socket API usage down. Scan a PR's first run
+      # (opened/reopened) and merges to main; on later PR pushes (synchronize)
+      # only when a dependency manifest changed, so we don't re-scan every commit.
+      - name: Decide whether to scan
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          scan=false
+          if [ "${{ github.event_name }}" = "push" ]; then
+            scan=true
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            case "${{ github.event.action }}" in
+              opened|reopened)
+                scan=true
+                ;;
+              synchronize)
+                if gh api --paginate \
+                     "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+                     --jq '.[].filename' | grep -qE '(^|/)package(-lock)?\.json$'; then
+                  scan=true
+                fi
+                ;;
+            esac
+          fi
+          echo "scan=$scan" >> "$GITHUB_OUTPUT"
+          echo "Socket scan for ${{ github.event_name }}/${{ github.event.action }}: $scan"
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        if: steps.gate.outputs.scan == 'true'
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        if: steps.gate.outputs.scan == 'true'
         with:
           python-version: "3.14"
+
       - name: Install Socket CLI
+        if: steps.gate.outputs.scan == 'true'
         run: pip install socketsecurity==2.2.83
+
       - name: Run Socket Security Scan
+        if: steps.gate.outputs.scan == 'true'
         env:
           SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_TOKEN }}
           GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=0
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
             PR_NUMBER=${{ github.event.pull_request.number }}
           fi
-          socketcli \
-            --target-path $GITHUB_WORKSPACE \
-            --scm github \
-            --pr-number $PR_NUMBER
+          # Retry only transient Socket API failures (e.g. a 429 rate limit);
+          # fail fast on a real policy violation so a genuine finding still blocks.
+          set +e
+          attempt=1
+          max=3
+          while true; do
+            socketcli --target-path "$GITHUB_WORKSPACE" --scm github --pr-number "$PR_NUMBER" 2>&1 | tee /tmp/socket-out.txt
+            rc=${PIPESTATUS[0]}
+            if [ "$rc" -eq 0 ]; then
+              break
+            fi
+            if grep -qiE 'API Error|rate.?limit|429|50[234]|Retry-After|timeout|timed out|temporarily' /tmp/socket-out.txt; then
+              if [ "$attempt" -ge "$max" ]; then
+                echo "Socket API still failing after $max attempts; giving up."
+                exit 1
+              fi
+              echo "Transient Socket API error (attempt $attempt/$max); retrying in 60s..."
+              attempt=$((attempt + 1))
+              sleep 60
+              continue
+            fi
+            echo "Socket scan failed (non-transient, e.g. a policy violation)."
+            exit "$rc"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-06-13
+
+### Added
+- **Fable 5, with a model/thinking/context pill.** The chat input gained Fable 5 as a selectable model, an "off" thinking level, and a compact pill showing the session's current model, thinking level, and context window — tap it to switch any of them inline. The model picker also drops the redundant model-id text from each row and always shows the version pills (a single pill for a single-version model).
+- **Open-session buttons in search.** Each global-search result and the message-context view now have a button that jumps straight into that session.
+- **Scroll position persists across navigation.** Every list page (sessions, settings, jobs, reviews, inbox, skills, commands, agents, hooks, MCP servers, plugins) restores its scroll position when you leave and return, instead of snapping back to the top. Search results also keep their scroll when you close the message-context view.
+
+### Fixed
+- **Cockpit wedged after a Claude CLI self-update.** Cockpit resolved the `claude` binary once and cached it for the server's lifetime. When the CLI self-updated and deleted the old versioned binary, every new session then failed to spawn with `claude exited during startup … execvp: No such file or directory` until cockpit was restarted. The cached path is now re-validated and re-resolved when it no longer exists.
+- **Unsaved custom-provider model dropped on Save.** On the provider editor's Models tab, a model you typed but hadn't committed with "+ Add model" (or an in-progress inline edit) was silently lost when you clicked the bottom Save. Both are now folded into the provider on Save.
+- **Session delete after "Load all".** Deleting a session in a folder expanded with "Load all" appeared to do nothing — the session was deleted on disk but the expanded list kept a stale copy until a reload. The list now refreshes after a delete. The per-row delete control is also always visible on mobile instead of only on hover.
+- **Model and thinking level reverting across a restart.** The `/model` slash command and the cockpit assistant's model/thinking selections now persist across a server restart instead of reverting to a stale or default value.
+- **Continuing a cleared or compacted session from history.** Sending from a history view now continues the exact transcript link you are viewing instead of diverging to the conversation's head, so new turns no longer disappear on refresh.
+- **Duplicate thinking strips on Fable turns.** Fable emits several thinking blocks per turn; the transcript rendered each as its own strip. Adjacent thinking blocks are now coalesced into one.
+- **Keyboard access for search and session cards.** Search results and session rows were invalid button-inside-button markup; they are now proper controls that activate with Enter or Space and keep their secondary actions (open, copy, delete) working.
+
 ## [0.4.0] - 2026-06-11
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alexjbarnes/cockpit",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alexjbarnes/cockpit",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alexjbarnes/cockpit",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Web UI for Claude Code",
   "license": "Apache-2.0",
   "author": "Alex Barnes (https://github.com/alexjbarnes)",

--- a/src/app/(app)/agents/page.tsx
+++ b/src/app/(app)/agents/page.tsx
@@ -9,9 +9,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useAgents } from "@/hooks/use-agents";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 
 export default function AgentsPage() {
   usePageHeader("Agents", { hideActions: true });
+  const scrollRef = useScrollRestoration<HTMLDivElement>("agents-scroll");
 
   const cwd = typeof localStorage !== "undefined" ? localStorage.getItem("cockpit-agents-cwd") || undefined : undefined;
 
@@ -43,7 +45,7 @@ export default function AgentsPage() {
   }
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
         <div />
         <Button size="sm" onClick={() => setScopeDialog(true)}>

--- a/src/app/(app)/commands/page.tsx
+++ b/src/app/(app)/commands/page.tsx
@@ -9,9 +9,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useCommands } from "@/hooks/use-commands";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 
 export default function CommandsPage() {
   usePageHeader("Commands", { hideActions: true });
+  const scrollRef = useScrollRestoration<HTMLDivElement>("commands-scroll");
 
   const cwd = typeof localStorage !== "undefined" ? localStorage.getItem("cockpit-agents-cwd") || undefined : undefined;
 
@@ -43,7 +45,7 @@ export default function CommandsPage() {
   }
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
         <div />
         <Button size="sm" onClick={() => setScopeDialog(true)}>

--- a/src/app/(app)/hooks/page.tsx
+++ b/src/app/(app)/hooks/page.tsx
@@ -5,6 +5,7 @@ import { usePageHeader } from "@/components/app-shell";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useHooks } from "@/hooks/use-hooks";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 
 const SCOPE_LABELS: Record<string, string> = {
   global: "Global",
@@ -16,6 +17,7 @@ const BLOCKING_EVENTS = new Set(["UserPromptSubmit", "PreToolUse", "PermissionRe
 
 export default function HooksPage() {
   usePageHeader("Hooks", { hideActions: true });
+  const scrollRef = useScrollRestoration<HTMLDivElement>("hooks-scroll");
 
   const cwd = typeof localStorage !== "undefined" ? localStorage.getItem("cockpit-agents-cwd") || undefined : undefined;
 
@@ -43,7 +45,7 @@ export default function HooksPage() {
   }
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
         <div />
         <button

--- a/src/app/(app)/inbox/page.tsx
+++ b/src/app/(app)/inbox/page.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useState } from "react";
 import { usePageHeader } from "@/components/app-shell";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 import type { InboxMessage } from "@/types";
 
 function priorityIcon(priority: string) {
@@ -32,6 +33,7 @@ function timeAgo(ts: number): string {
 
 export default function InboxPage() {
   usePageHeader("Inbox", { hideActions: true });
+  const scrollRef = useScrollRestoration<HTMLDivElement>("inbox-scroll");
 
   const router = useRouter();
   const [messages, setMessages] = useState<InboxMessage[]>([]);
@@ -99,7 +101,7 @@ export default function InboxPage() {
   const unreadCount = messages.filter((m) => !m.read).length;
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
         <div className="text-sm text-muted-foreground">
           {messages.length > 0 && (

--- a/src/app/(app)/jobs/[id]/edit/page.tsx
+++ b/src/app/(app)/jobs/[id]/edit/page.tsx
@@ -29,6 +29,7 @@ const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", 
 const COMMON_TOOLS = ["Read", "Write", "Edit", "Bash", "Bash git", "Bash npm", "Bash ls", "Grep", "Glob", "Agent", "WebFetch", "WebSearch"];
 
 const THINKING_LABELS: Record<ThinkingLevel, string> = {
+  off: "Off",
   low: "Low",
   medium: "Medium",
   high: "High",
@@ -573,7 +574,7 @@ export default function JobEditPage() {
               <div className="flex items-center justify-between px-2 py-2 text-sm">
                 <span>Model</span>
                 <div className="flex gap-1 flex-wrap justify-end">
-                  {(["haiku", "sonnet", "opus"] as ModelAlias[]).map((alias) => (
+                  {(["haiku", "sonnet", "opus", "fable"] as ModelAlias[]).map((alias) => (
                     <Button
                       key={alias}
                       variant={selectedAlias === alias ? "default" : "outline"}
@@ -645,7 +646,7 @@ export default function JobEditPage() {
               <div className="flex items-center justify-between px-2 py-2 text-sm">
                 <span>Thinking</span>
                 <div className="flex gap-1 flex-wrap justify-end">
-                  {effortLevels.map((level) => (
+                  {(["off", ...effortLevels] as ThinkingLevel[]).map((level) => (
                     <Button
                       key={level}
                       variant={thinkingLevel === level ? "default" : "outline"}

--- a/src/app/(app)/jobs/page.tsx
+++ b/src/app/(app)/jobs/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useJobs } from "@/hooks/use-jobs";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 import { type JobDisplayStatus, jobDisplayStatus } from "@/lib/job-display";
 import { describeAllSchedules, getJobSchedules, getNextRunTimeAny } from "@/server/cron-utils";
 import type { ScheduledJob } from "@/types";
@@ -272,6 +273,7 @@ function JobDirGroup({
 
 export default function JobsPage() {
   usePageHeader("Scheduled Jobs", { hideActions: true });
+  const scrollRef = useScrollRestoration<HTMLDivElement>("jobs-scroll");
 
   const { jobs, loading, deleteJob, triggerJob, stopJob, refresh } = useJobs();
   const router = useRouter();
@@ -327,7 +329,7 @@ export default function JobsPage() {
   }
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 pb-24 space-y-4">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 pb-24 space-y-4">
       {loading && <p className="text-sm text-muted-foreground">Loading jobs...</p>}
 
       {!loading && jobs.length === 0 && (

--- a/src/app/(app)/mcp-servers/page.tsx
+++ b/src/app/(app)/mcp-servers/page.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { type McpServerConfig, useMcpServers } from "@/hooks/use-mcp-servers";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 
 export default function McpServersPage() {
   usePageHeader("MCP Servers", { hideActions: true });
@@ -49,6 +50,7 @@ function McpServerList({
   loading: boolean;
 }) {
   const router = useRouter();
+  const scrollRef = useScrollRestoration<HTMLDivElement>("mcp-servers-scroll");
   const [scopeDialog, setScopeDialog] = useState(false);
   const [pickingDir, setPickingDir] = useState(false);
 
@@ -68,7 +70,7 @@ function McpServerList({
   }
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
         <div />
         <Button size="sm" onClick={() => setScopeDialog(true)}>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -2,12 +2,14 @@
 
 import { usePageHeader } from "@/components/app-shell";
 import { SessionList } from "@/components/session-list";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 
 export default function HomePage() {
   usePageHeader("Cockpit", { usageOnly: true });
+  const scrollRef = useScrollRestoration<HTMLDivElement>("sessions-scroll");
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto">
       <SessionList />
     </div>
   );

--- a/src/app/(app)/plugins/page.tsx
+++ b/src/app/(app)/plugins/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { type AvailablePlugin, type InstalledPlugin, type Marketplace, type PluginScope, usePlugins } from "@/hooks/use-plugins";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 
 type Tab = "installed" | "browse" | "marketplaces";
 
@@ -20,6 +21,7 @@ const MKT_ALL = "__all__";
 
 export default function PluginsPage() {
   usePageHeader("Plugins", { hideActions: true });
+  const scrollRef = useScrollRestoration<HTMLDivElement>("plugins-scroll");
   const router = useRouter();
   const searchParams = useSearchParams();
   const detailId = searchParams.get("detail");
@@ -118,7 +120,7 @@ export default function PluginsPage() {
   }
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1">
           <TabButton active={tab === "installed"} onClick={() => setTab("installed")} label="Installed" count={installed.length} />

--- a/src/app/(app)/reviews/page.tsx
+++ b/src/app/(app)/reviews/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { usePageHeader } from "@/components/app-shell";
 import { Button } from "@/components/ui/button";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 import { cn } from "@/lib/utils";
 
 const SELECTED_ORG_KEY = "cockpit_review_org";
@@ -37,6 +38,7 @@ function timeAgo(dateStr: string): string {
 
 export default function ReviewsPage() {
   usePageHeader("Reviews");
+  const scrollRef = useScrollRestoration<HTMLDivElement>("reviews-scroll");
 
   const router = useRouter();
   const [orgs, setOrgs] = useState<string[]>(cachedOrgs || []);
@@ -162,7 +164,7 @@ export default function ReviewsPage() {
   }
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
       {/* Org selector */}
       <div className="flex gap-2 flex-wrap">
         {orgs.map((org) => (

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { usePageHeader } from "@/components/app-shell";
 import { Button } from "@/components/ui/button";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 
 interface VersionInfo {
   installed: string;
@@ -222,6 +223,7 @@ export default function SettingsPage() {
   const [ccChangelogExpanded, setCcChangelogExpanded] = useState(false);
   const [ccExpandedVersions, setCcExpandedVersions] = useState<Set<string>>(new Set());
   const router = useRouter();
+  const scrollRef = useScrollRestoration<HTMLDivElement>("settings-scroll");
 
   usePageHeader("Settings", { hideActions: true });
 
@@ -311,7 +313,7 @@ export default function SettingsPage() {
   }, []);
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 sm:p-6">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 sm:p-6">
       <div className="space-y-3">
         <div className="min-h-[104px]">
           {(versionLoading || version) && (

--- a/src/app/(app)/settings/session/page.tsx
+++ b/src/app/(app)/settings/session/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/models";
 
 const thinkingOptions: { value: ThinkingLevel; label: string }[] = [
+  { value: "off", label: "Off" },
   { value: "low", label: "Low" },
   { value: "medium", label: "Medium" },
   { value: "high", label: "High" },
@@ -78,7 +79,9 @@ export default function SessionSettingsPage() {
   const versions = versionsForAlias(selectedAlias);
   const showVersions = versions.length > 1;
   const effortLevels = allowedEffortLevels(entry);
-  const visibleThinking = thinkingOptions.filter((opt) => effortLevels.includes(opt.value as ThinkingLevel));
+  const visibleThinking = thinkingOptions.filter((opt) =>
+    opt.value === "off" ? effortLevels.length > 0 : effortLevels.includes(opt.value as ThinkingLevel),
+  );
 
   function selectAlias(alias: ModelAlias) {
     const def = defaultForAlias(alias);
@@ -122,6 +125,7 @@ export default function SessionSettingsPage() {
                 { value: "haiku", label: "Haiku" },
                 { value: "sonnet", label: "Sonnet" },
                 { value: "opus", label: "Opus" },
+                { value: "fable", label: "Fable" },
               ] as { value: string; label: string }[]
             }
             value={selectedAlias}

--- a/src/app/(app)/skills/page.tsx
+++ b/src/app/(app)/skills/page.tsx
@@ -8,10 +8,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 import { useSkills } from "@/hooks/use-skills";
 
 export default function SkillsPage() {
   usePageHeader("Skills", { hideActions: true });
+  const scrollRef = useScrollRestoration<HTMLDivElement>("skills-scroll");
 
   const cwd = typeof localStorage !== "undefined" ? localStorage.getItem("cockpit-agents-cwd") || undefined : undefined;
 
@@ -43,7 +45,7 @@ export default function SkillsPage() {
   }
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+    <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
         <div />
         <Button size="sm" onClick={() => setScopeDialog(true)}>

--- a/src/components/global-search-modal.tsx
+++ b/src/components/global-search-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Check, Copy, Folder, Loader2, Search, X } from "lucide-react";
+import { ArrowUpRight, Check, Copy, Folder, Loader2, Search, X } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -51,6 +52,15 @@ function GlobalSearchModal({ onClose }: { onClose: () => void }) {
   const [contextResult, setContextResult] = useState<GlobalSearchResult | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const router = useRouter();
+
+  const openSession = useCallback(
+    (result: GlobalSearchResult) => {
+      router.push(`/sessions/${result.sessionId}?cwd=${encodeURIComponent(result.cwd)}&historyView=true`);
+      onClose();
+    },
+    [router, onClose],
+  );
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -178,6 +188,18 @@ function GlobalSearchModal({ onClose }: { onClose: () => void }) {
                 </Badge>
                 <span className="text-xs text-muted-foreground">{new Date(result.timestamp).toLocaleString()}</span>
                 <div className="ml-auto flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 shrink-0"
+                    title="Open session"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      openSession(result);
+                    }}
+                  >
+                    <ArrowUpRight className="h-3 w-3" />
+                  </Button>
                   <CopyButton text={result.fullContent} />
                 </div>
               </div>

--- a/src/components/global-search-modal.tsx
+++ b/src/components/global-search-modal.tsx
@@ -170,9 +170,17 @@ function GlobalSearchModal({ onClose }: { onClose: () => void }) {
           <div className="flex-1 min-h-0 overflow-y-auto">
             {searched && results.length === 0 && <div className="p-8 text-center text-sm text-muted-foreground">No results</div>}
             {results.map((result, i) => (
-              <button
+              <div
                 key={`${result.messageId}-${i}`}
+                role="button"
+                tabIndex={0}
                 onClick={() => setContextResult(result)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setContextResult(result);
+                  }
+                }}
                 className="w-full text-left p-4 border-b last:border-b-0 hover:bg-muted/50 transition-colors cursor-pointer"
               >
                 <div className="flex items-center gap-2 mb-1">
@@ -204,7 +212,7 @@ function GlobalSearchModal({ onClose }: { onClose: () => void }) {
                   <div className="truncate pl-[18px]">{result.sessionName}</div>
                 </div>
                 <HighlightedPreview preview={result.preview} matchStart={result.matchStart} matchLength={result.matchLength} />
-              </button>
+              </div>
             ))}
           </div>
           {stats && searched && results.length > 0 && (

--- a/src/components/global-search-modal.tsx
+++ b/src/components/global-search-modal.tsx
@@ -146,88 +146,90 @@ function GlobalSearchModal({ onClose }: { onClose: () => void }) {
     return () => window.removeEventListener("keydown", handler, true);
   }, [onClose]);
 
-  if (contextResult) {
-    return (
-      <MessageContextModal
-        timestamp={contextResult.timestamp}
-        sessionId={contextResult.sessionId}
-        cwd={contextResult.cwd}
-        onClose={() => setContextResult(null)}
-      />
-    );
-  }
-
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" onClick={handleOverlayClick}>
-      <Card className="w-full max-w-2xl flex flex-col" style={{ maxHeight: "calc(100dvh - 2rem)" }}>
-        <div className="flex items-center gap-2 p-4 border-b">
-          <Search className="h-4 w-4 text-muted-foreground shrink-0" />
-          <input
-            ref={inputRef}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search all session messages..."
-            className="flex-1 bg-transparent outline-none text-sm"
-          />
-          {loading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground shrink-0" />}
-          <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={onClose}>
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-        <div className="flex-1 min-h-0 overflow-y-auto">
-          {searched && results.length === 0 && <div className="p-8 text-center text-sm text-muted-foreground">No results</div>}
-          {results.map((result, i) => (
-            <button
-              key={`${result.messageId}-${i}`}
-              onClick={() => setContextResult(result)}
-              className="w-full text-left p-4 border-b last:border-b-0 hover:bg-muted/50 transition-colors cursor-pointer"
-            >
-              <div className="flex items-center gap-2 mb-1">
-                <Badge variant={result.role === "user" ? "default" : "secondary"} className="text-[10px] px-1.5 py-0">
-                  {result.role === "user" ? "User" : "Assistant"}
-                </Badge>
-                <span className="text-xs text-muted-foreground">{new Date(result.timestamp).toLocaleString()}</span>
-                <div className="ml-auto flex items-center gap-1">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 shrink-0"
-                    title="Open session"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      openSession(result);
-                    }}
-                  >
-                    <ArrowUpRight className="h-3 w-3" />
-                  </Button>
-                  <CopyButton text={result.fullContent} />
-                </div>
-              </div>
-              <div className="mb-1.5 text-[11px] text-muted-foreground">
-                <div className="flex items-center gap-1.5">
-                  <Folder className="h-3 w-3 shrink-0" />
-                  <span className="truncate">{result.dirName}</span>
-                </div>
-                <div className="truncate pl-[18px]">{result.sessionName}</div>
-              </div>
-              <HighlightedPreview preview={result.preview} matchStart={result.matchStart} matchLength={result.matchLength} />
-            </button>
-          ))}
-        </div>
-        {stats && searched && results.length > 0 && (
-          <div className="px-4 py-2 border-t text-[11px] text-muted-foreground flex items-center justify-between">
-            <span>
-              {results.length} result{results.length !== 1 ? "s" : ""} across {stats.total} session{stats.total !== 1 ? "s" : ""}
-            </span>
-            {stats.truncated && (
-              <button onClick={loadMore} disabled={loadingMore} className="text-[11px] text-primary hover:underline disabled:opacity-50">
-                {loadingMore ? "Loading..." : "Load more"}
-              </button>
-            )}
+    <>
+      {/* The results list stays mounted while the context modal overlays it, so
+          its scroll position is preserved when you close the modal and continue
+          browsing. */}
+      <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" onClick={handleOverlayClick}>
+        <Card className="w-full max-w-2xl flex flex-col" style={{ maxHeight: "calc(100dvh - 2rem)" }}>
+          <div className="flex items-center gap-2 p-4 border-b">
+            <Search className="h-4 w-4 text-muted-foreground shrink-0" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search all session messages..."
+              className="flex-1 bg-transparent outline-none text-sm"
+            />
+            {loading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground shrink-0" />}
+            <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={onClose}>
+              <X className="h-4 w-4" />
+            </Button>
           </div>
-        )}
-      </Card>
-    </div>
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {searched && results.length === 0 && <div className="p-8 text-center text-sm text-muted-foreground">No results</div>}
+            {results.map((result, i) => (
+              <button
+                key={`${result.messageId}-${i}`}
+                onClick={() => setContextResult(result)}
+                className="w-full text-left p-4 border-b last:border-b-0 hover:bg-muted/50 transition-colors cursor-pointer"
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <Badge variant={result.role === "user" ? "default" : "secondary"} className="text-[10px] px-1.5 py-0">
+                    {result.role === "user" ? "User" : "Assistant"}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground">{new Date(result.timestamp).toLocaleString()}</span>
+                  <div className="ml-auto flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 shrink-0"
+                      title="Open session"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openSession(result);
+                      }}
+                    >
+                      <ArrowUpRight className="h-3 w-3" />
+                    </Button>
+                    <CopyButton text={result.fullContent} />
+                  </div>
+                </div>
+                <div className="mb-1.5 text-[11px] text-muted-foreground">
+                  <div className="flex items-center gap-1.5">
+                    <Folder className="h-3 w-3 shrink-0" />
+                    <span className="truncate">{result.dirName}</span>
+                  </div>
+                  <div className="truncate pl-[18px]">{result.sessionName}</div>
+                </div>
+                <HighlightedPreview preview={result.preview} matchStart={result.matchStart} matchLength={result.matchLength} />
+              </button>
+            ))}
+          </div>
+          {stats && searched && results.length > 0 && (
+            <div className="px-4 py-2 border-t text-[11px] text-muted-foreground flex items-center justify-between">
+              <span>
+                {results.length} result{results.length !== 1 ? "s" : ""} across {stats.total} session{stats.total !== 1 ? "s" : ""}
+              </span>
+              {stats.truncated && (
+                <button onClick={loadMore} disabled={loadingMore} className="text-[11px] text-primary hover:underline disabled:opacity-50">
+                  {loadingMore ? "Loading..." : "Load more"}
+                </button>
+              )}
+            </div>
+          )}
+        </Card>
+      </div>
+      {contextResult && (
+        <MessageContextModal
+          timestamp={contextResult.timestamp}
+          sessionId={contextResult.sessionId}
+          cwd={contextResult.cwd}
+          onClose={() => setContextResult(null)}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/components/input-area.tsx
+++ b/src/components/input-area.tsx
@@ -1272,7 +1272,7 @@ export function InputArea({
                       : "Send a message..."
               }
               rows={2}
-              className={`w-full resize-none rounded-md border bg-background px-3 py-2 pb-7 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 overflow-y-auto scrollbar-none ${
+              className={`block w-full resize-none rounded-md border bg-background px-3 py-2 pb-7 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 overflow-y-auto scrollbar-none ${
                 planMode ? "border-blue-500/50 focus-visible:ring-blue-500/50" : "border-input focus-visible:ring-ring"
               }`}
             />

--- a/src/components/input-area.tsx
+++ b/src/components/input-area.tsx
@@ -40,6 +40,7 @@ import {
   CONTEXT_SIZES,
   type ContextSize,
   defaultForAlias,
+  describeModelSelection,
   findModelById,
   type ModelAlias,
   type ModelEntry,
@@ -65,6 +66,7 @@ const aliases: { value: ModelAlias; label: string }[] = [
   { value: "haiku", label: "Haiku" },
   { value: "sonnet", label: "Sonnet" },
   { value: "opus", label: "Opus" },
+  { value: "fable", label: "Fable" },
 ];
 
 function parseCurrentModel(
@@ -72,7 +74,7 @@ function parseCurrentModel(
   currentContextSize: ContextSize,
 ): { alias: ModelAlias | null; entry: ModelEntry | null; contextSize: ContextSize } {
   const base = currentModel.replace(/\[.*\]$/, "");
-  if (base === "opus" || base === "sonnet" || base === "haiku") {
+  if (base === "opus" || base === "sonnet" || base === "haiku" || base === "fable") {
     return { alias: base, entry: defaultForAlias(base) ?? null, contextSize: currentContextSize };
   }
   const entry = findModelById(base) ?? null;
@@ -92,6 +94,7 @@ function valueForAlias(alias: ModelAlias): string {
 }
 
 const thinkingLevels: { value: ThinkingLevel; label: string }[] = [
+  { value: "off", label: "Off" },
   { value: "low", label: "Low" },
   { value: "medium", label: "Medium" },
   { value: "high", label: "High" },
@@ -332,6 +335,7 @@ export function InputArea({
   const [historyOpen, setHistoryOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [optionsOpen, setOptionsOpen] = useState(false);
+  const [inputFocused, setInputFocused] = useState(false);
   const [settingsTab, setSettingsTab] = useState<"model" | "runtime">("model");
   const [viewProvider, setViewProvider] = useState<string>("anthropic");
   const [mentionSelectedIndex, setMentionSelectedIndex] = useState(0);
@@ -737,6 +741,10 @@ export function InputArea({
     [addFiles],
   );
 
+  const modelSelection = describeModelSelection(currentModel, thinkingLevel, currentContextSize, providers);
+  const thinkingLabel = modelSelection.thinking ? (thinkingLevels.find((t) => t.value === modelSelection.thinking)?.label ?? null) : null;
+  const contextLabel = modelSelection.context ? CONTEXT_SIZES[modelSelection.context].label : null;
+
   return (
     <div
       className={`border-t bg-background px-1 pt-2 pb-1 ${dragOver ? "ring-2 ring-primary ring-inset" : ""}`}
@@ -798,7 +806,9 @@ export function InputArea({
               return [];
             })();
             const allowed = new Set(providerEffort.length > 0 ? providerEffort : allowedEffortLevels(parsed.entry));
-            const visibleLevels = thinkingLevels.filter((opt) => allowed.has(opt.value));
+            // "Off" (disable thinking) is offered whenever the model can think; the
+            // effort levels show only when allowed. It is not an --effort value.
+            const visibleLevels = thinkingLevels.filter((opt) => (opt.value === "off" ? allowed.size > 0 : allowed.has(opt.value)));
 
             return (
               <div
@@ -1248,6 +1258,8 @@ export function InputArea({
               onKeyDown={handleKeyDown}
               onInput={handleInput}
               onPaste={handlePaste}
+              onFocus={() => setInputFocused(true)}
+              onBlur={() => setInputFocused(false)}
               placeholder={
                 hasQueuedMessage
                   ? queuePaused
@@ -1271,6 +1283,24 @@ export function InputArea({
             >
               <Paperclip className="h-4 w-4" />
             </button>
+            {!inputFocused && (
+              <button
+                type="button"
+                data-testid="model-pill"
+                title="Model and thinking level — click to change"
+                onClick={() => {
+                  const p = parseCurrentModel(currentModel, currentContextSize);
+                  setViewProvider(p.alias ? "anthropic" : resolveProviderId(currentModel, providers));
+                  setOptionsOpen(true);
+                }}
+                className="absolute bottom-2.5 left-2.5 flex max-w-[60%] items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground"
+              >
+                <Cpu className="h-2.5 w-2.5 shrink-0" />
+                <span className="truncate">{modelSelection.label}</span>
+                {thinkingLabel && <span className="shrink-0 text-muted-foreground/60">· {thinkingLabel}</span>}
+                {contextLabel && <span className="shrink-0 text-muted-foreground/60">· {contextLabel}</span>}
+              </button>
+            )}
           </div>
           <div className="flex flex-col items-center justify-center w-12 shrink-0 overflow-visible">
             {!connected ? (

--- a/src/components/input-area.tsx
+++ b/src/components/input-area.tsx
@@ -785,7 +785,9 @@ export function InputArea({
               ...(providers || []).filter((p) => !p.isBuiltin).map((p) => ({ id: p.id, name: p.name })),
             ];
             const vEntries = parsed.alias ? versionsForAlias(parsed.alias) : [];
-            const showVRow = vEntries.length > 1;
+            // Always show the version row for an Anthropic alias (single-version
+            // models render one pill); custom-provider models have no alias versions.
+            const showVRow = vEntries.length >= 1;
             const matchesProviderModel = (p: Provider, pm: ProviderModel): boolean =>
               currentModel === pm.modelId || currentModel === `${p.id}:${pm.modelId}`;
             const sizes: ContextSize[] = (() => {
@@ -887,7 +889,6 @@ export function InputArea({
                           {viewProvider === "anthropic" ? (
                             <div className="space-y-0.5">
                               {aliases.map((opt) => {
-                                const entry = defaultForAlias(opt.value);
                                 const selected = parsed.alias === opt.value;
                                 return (
                                   <button
@@ -905,7 +906,6 @@ export function InputArea({
                                       )}
                                     </div>
                                     <span className="font-mono font-medium">{opt.label}</span>
-                                    {entry && <span className="text-muted-foreground ml-auto">{entry.modelId}</span>}
                                   </button>
                                 );
                               })}

--- a/src/components/message-context-modal.tsx
+++ b/src/components/message-context-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Loader2, X } from "lucide-react";
+import { ArrowUpRight, Loader2, X } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -18,6 +19,7 @@ interface MessageContextModalProps {
 export function MessageContextModal(props: MessageContextModalProps) {
   const { timestamp, onClose } = props;
   const shell = useShell();
+  const router = useRouter();
   const sessionId = props.sessionId ?? shell.sessionId;
   const cwd = props.cwd ?? shell.cwd;
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -77,9 +79,26 @@ export function MessageContextModal(props: MessageContextModalProps) {
       <Card className="w-full max-w-3xl flex flex-col" style={{ maxHeight: "calc(100dvh - 2rem)" }}>
         <div className="flex items-center justify-between px-4 py-2 border-b shrink-0">
           <span className="text-sm font-medium text-muted-foreground">Message context</span>
-          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onClose}>
-            <X className="h-4 w-4" />
-          </Button>
+          <div className="flex items-center gap-1">
+            {props.sessionId && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 gap-1 px-2 text-xs"
+                title="Open session"
+                onClick={() => {
+                  router.push(`/sessions/${sessionId}?cwd=${encodeURIComponent(cwd ?? "")}&historyView=true`);
+                  onClose();
+                }}
+              >
+                <ArrowUpRight className="h-3 w-3" />
+                Open session
+              </Button>
+            )}
+            <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onClose}>
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
           {loading && (

--- a/src/components/provider-form.tsx
+++ b/src/components/provider-form.tsx
@@ -31,6 +31,17 @@ interface EditingModel {
   contextSizes: ContextSize[];
 }
 
+function buildModel(modelId: string, displayName: string, effortLevels: ThinkingLevel[], contextSizes: ContextSize[]): ProviderModel {
+  const cleanId = modelId.trim().replace(/\[.*\]$/, "");
+  return { modelId: cleanId, displayName: displayName.trim() || cleanId, effortLevels, contextSizes };
+}
+
+// A draft / inline edit is committable on the same terms as the explicit
+// "Add model" / inner "Save" buttons: a non-empty id and at least one context size.
+function isCommittable(modelId: string, contextSizes: ContextSize[]): boolean {
+  return modelId.trim().replace(/\[.*\]$/, "") !== "" && contextSizes.length > 0;
+}
+
 function EffortPills({ selected, onChange }: { selected: ThinkingLevel[]; onChange: (levels: ThinkingLevel[]) => void }) {
   return (
     <div className="ml-auto flex flex-wrap gap-1 justify-end">
@@ -104,13 +115,28 @@ export function ProviderForm({ provider, isNew, onSave, onCancel, onDelete, lock
 
   const handleSave = async () => {
     if (!name.trim()) return;
+
+    // Fold any in-progress inline edit and the unsaved draft into the list so the
+    // bottom Save never silently drops a model the user typed but didn't commit
+    // with the inner "Save" / "Add model" button. This was a repeated footgun.
+    let nextModels = models;
+    if (editingModel && isCommittable(editingModel.modelId, editingModel.contextSizes)) {
+      const edit = editingModel;
+      nextModels = nextModels.map((m, i) =>
+        i === edit.index ? buildModel(edit.modelId, edit.displayName, edit.effortLevels, edit.contextSizes) : m,
+      );
+    }
+    if (isCommittable(newModelId, newModelContextSizes)) {
+      nextModels = [...nextModels, buildModel(newModelId, newModelName, newModelEffort, newModelContextSizes)];
+    }
+
     setSaving(true);
     try {
       await onSave({
         ...provider,
         name,
         envVars: Object.fromEntries(envVars),
-        models,
+        models: nextModels,
       });
     } finally {
       setSaving(false);
@@ -126,39 +152,20 @@ export function ProviderForm({ provider, isNew, onSave, onCancel, onDelete, lock
   };
 
   const addModel = () => {
-    const cleanId = newModelId.trim().replace(/\[.*\]$/, "");
-    if (cleanId && newModelContextSizes.length > 0) {
-      setModels([
-        ...models,
-        {
-          modelId: cleanId,
-          displayName: newModelName.trim() || cleanId,
-          effortLevels: newModelEffort,
-          contextSizes: newModelContextSizes,
-        },
-      ]);
-      setNewModelId("");
-      setNewModelName("");
-      setNewModelEffort([]);
-      setNewModelContextSizes(["200k"]);
-    }
+    if (!isCommittable(newModelId, newModelContextSizes)) return;
+    setModels([...models, buildModel(newModelId, newModelName, newModelEffort, newModelContextSizes)]);
+    setNewModelId("");
+    setNewModelName("");
+    setNewModelEffort([]);
+    setNewModelContextSizes(["200k"]);
   };
 
   const saveEditingModel = () => {
     if (!editingModel) return;
-    if (editingModel.contextSizes.length === 0) return;
-    const cleanId = editingModel.modelId.trim().replace(/\[.*\]$/, "");
+    if (!isCommittable(editingModel.modelId, editingModel.contextSizes)) return;
+    const edit = editingModel;
     setModels(
-      models.map((m, i) =>
-        i === editingModel.index
-          ? {
-              modelId: cleanId,
-              displayName: editingModel.displayName.trim() || cleanId,
-              effortLevels: editingModel.effortLevels,
-              contextSizes: editingModel.contextSizes,
-            }
-          : m,
-      ),
+      models.map((m, i) => (i === edit.index ? buildModel(edit.modelId, edit.displayName, edit.effortLevels, edit.contextSizes) : m)),
     );
     setEditingModel(null);
   };

--- a/src/components/search-modal.tsx
+++ b/src/components/search-modal.tsx
@@ -155,9 +155,17 @@ function SearchModal({ onClose }: { onClose: () => void }) {
           <div className="flex-1 min-h-0 overflow-y-auto">
             {searched && results.length === 0 && <div className="p-8 text-center text-sm text-muted-foreground">No results</div>}
             {results.map((result, i) => (
-              <button
+              <div
                 key={`${result.messageId}-${i}`}
+                role="button"
+                tabIndex={0}
                 onClick={() => handleResultClick(result.timestamp)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleResultClick(result.timestamp);
+                  }
+                }}
                 className="w-full text-left p-4 border-b last:border-b-0 hover:bg-muted/50 transition-colors cursor-pointer"
               >
                 <div className="flex items-center gap-2 mb-1">
@@ -170,7 +178,7 @@ function SearchModal({ onClose }: { onClose: () => void }) {
                   </div>
                 </div>
                 <HighlightedPreview preview={result.preview} matchStart={result.matchStart} matchLength={result.matchLength} />
-              </button>
+              </div>
             ))}
           </div>
         </Card>

--- a/src/components/search-modal.tsx
+++ b/src/components/search-modal.tsx
@@ -132,50 +132,51 @@ function SearchModal({ onClose }: { onClose: () => void }) {
     return () => window.removeEventListener("keydown", handler, true);
   }, [onClose]);
 
-  if (contextTimestamp !== null) {
-    return <MessageContextModal timestamp={contextTimestamp} onClose={() => setContextTimestamp(null)} />;
-  }
-
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" onClick={handleOverlayClick}>
-      <Card className="w-full max-w-2xl flex flex-col" style={{ maxHeight: "calc(100dvh - 2rem)" }}>
-        <div className="flex items-center gap-2 p-4 border-b">
-          <Search className="h-4 w-4 text-muted-foreground shrink-0" />
-          <input
-            ref={inputRef}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search messages..."
-            className="flex-1 bg-transparent outline-none text-sm"
-          />
-          {loading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground shrink-0" />}
-          <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={onClose}>
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-        <div className="flex-1 min-h-0 overflow-y-auto">
-          {searched && results.length === 0 && <div className="p-8 text-center text-sm text-muted-foreground">No results</div>}
-          {results.map((result, i) => (
-            <button
-              key={`${result.messageId}-${i}`}
-              onClick={() => handleResultClick(result.timestamp)}
-              className="w-full text-left p-4 border-b last:border-b-0 hover:bg-muted/50 transition-colors cursor-pointer"
-            >
-              <div className="flex items-center gap-2 mb-1">
-                <Badge variant={result.role === "user" ? "default" : "secondary"} className="text-[10px] px-1.5 py-0">
-                  {result.role === "user" ? "User" : "Assistant"}
-                </Badge>
-                <span className="text-xs text-muted-foreground select-text">{new Date(result.timestamp).toLocaleString()}</span>
-                <div className="ml-auto">
-                  <CopyButton text={result.fullContent} />
+    <>
+      {/* The results list stays mounted while the context modal overlays it, so its
+          scroll position is preserved when you close the modal and keep browsing. */}
+      <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" onClick={handleOverlayClick}>
+        <Card className="w-full max-w-2xl flex flex-col" style={{ maxHeight: "calc(100dvh - 2rem)" }}>
+          <div className="flex items-center gap-2 p-4 border-b">
+            <Search className="h-4 w-4 text-muted-foreground shrink-0" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search messages..."
+              className="flex-1 bg-transparent outline-none text-sm"
+            />
+            {loading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground shrink-0" />}
+            <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={onClose}>
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {searched && results.length === 0 && <div className="p-8 text-center text-sm text-muted-foreground">No results</div>}
+            {results.map((result, i) => (
+              <button
+                key={`${result.messageId}-${i}`}
+                onClick={() => handleResultClick(result.timestamp)}
+                className="w-full text-left p-4 border-b last:border-b-0 hover:bg-muted/50 transition-colors cursor-pointer"
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <Badge variant={result.role === "user" ? "default" : "secondary"} className="text-[10px] px-1.5 py-0">
+                    {result.role === "user" ? "User" : "Assistant"}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground select-text">{new Date(result.timestamp).toLocaleString()}</span>
+                  <div className="ml-auto">
+                    <CopyButton text={result.fullContent} />
+                  </div>
                 </div>
-              </div>
-              <HighlightedPreview preview={result.preview} matchStart={result.matchStart} matchLength={result.matchLength} />
-            </button>
-          ))}
-        </div>
-      </Card>
-    </div>
+                <HighlightedPreview preview={result.preview} matchStart={result.matchStart} matchLength={result.matchLength} />
+              </button>
+            ))}
+          </div>
+        </Card>
+      </div>
+      {contextTimestamp !== null && <MessageContextModal timestamp={contextTimestamp} onClose={() => setContextTimestamp(null)} />}
+    </>
   );
 }
 

--- a/src/components/session-card.tsx
+++ b/src/components/session-card.tsx
@@ -43,7 +43,7 @@ export function SessionCard({ session, onClick, onDelete }: SessionCardProps) {
               e.stopPropagation();
               onDelete(e);
             }}
-            className="p-1 rounded hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-opacity"
+            className="p-1 rounded hover:bg-destructive/10 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
             title="Delete session"
           >
             <Trash2 className="h-3.5 w-3.5 text-muted-foreground hover:text-destructive" />

--- a/src/components/session-card.tsx
+++ b/src/components/session-card.tsx
@@ -24,9 +24,17 @@ function timeAgo(ts: number): string {
 
 export function SessionCard({ session, onClick, onDelete }: SessionCardProps) {
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
-      className="w-full flex items-center gap-3 px-3 py-2 text-left rounded-md hover:bg-accent/50 transition-colors group"
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      className="w-full flex items-center gap-3 px-3 py-2 text-left rounded-md hover:bg-accent/50 transition-colors cursor-pointer group"
     >
       <span className="text-sm truncate flex-1">{session.name}</span>
       <div className="flex items-center gap-2 shrink-0">
@@ -37,8 +45,8 @@ export function SessionCard({ session, onClick, onDelete }: SessionCardProps) {
         )}
         <span className="text-xs text-muted-foreground">{timeAgo(session.lastActiveAt)}</span>
         {onDelete && session.status !== "running" && (
-          <span
-            role="button"
+          <button
+            type="button"
             onClick={(e) => {
               e.stopPropagation();
               onDelete(e);
@@ -47,9 +55,9 @@ export function SessionCard({ session, onClick, onDelete }: SessionCardProps) {
             title="Delete session"
           >
             <Trash2 className="h-3.5 w-3.5 text-muted-foreground hover:text-destructive" />
-          </span>
+          </button>
         )}
       </div>
-    </button>
+    </div>
   );
 }

--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -61,14 +61,14 @@ function DirectoryGroup({
   const [expanded, setExpanded] = useState(false);
   const [fullSessions, setFullSessions] = useState<SessionInfo[] | null>(null);
   const [loadingAll, setLoadingAll] = useState(false);
+  const showAllRef = useRef(false);
 
   const displaySessions = fullSessions || group.sessions;
   const truncated = displaySessions.length < group.totalSessionCount;
   const latestAt = displaySessions[0]?.lastActiveAt || 0;
   const runningCount = displaySessions.filter((s) => s.status === "running").length;
 
-  const loadAll = async () => {
-    if (loadingAll) return;
+  const loadAll = useCallback(async () => {
     setLoadingAll(true);
     try {
       const res = await fetch(`/api/sessions/group?cwd=${encodeURIComponent(group.cwd)}`);
@@ -79,7 +79,20 @@ function DirectoryGroup({
     } finally {
       setLoadingAll(false);
     }
+  }, [group.cwd]);
+
+  const handleLoadAll = () => {
+    showAllRef.current = true;
+    loadAll();
   };
+
+  // Once the full list is shown, re-pull it whenever the group changes upstream
+  // (a delete triggers a parent refetch, which decrements totalSessionCount), so
+  // a just-deleted session cannot linger in the stale expanded cache.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional re-trigger on group size change; loadAll is stable
+  useEffect(() => {
+    if (showAllRef.current) loadAll();
+  }, [group.totalSessionCount]);
 
   return (
     <div className="rounded-lg border bg-card">
@@ -123,7 +136,7 @@ function DirectoryGroup({
           ))}
           {truncated && (
             <button
-              onClick={loadAll}
+              onClick={handleLoadAll}
               disabled={loadingAll}
               className="w-full text-xs text-muted-foreground hover:text-foreground py-2 rounded hover:bg-accent/50 transition-colors disabled:opacity-50"
             >

--- a/src/hooks/use-scroll-restoration.ts
+++ b/src/hooks/use-scroll-restoration.ts
@@ -1,91 +1,95 @@
-import { useEffect, useLayoutEffect, useRef } from "react";
-
-// useLayoutEffect on the client (restore before paint, no flash); useEffect on
-// the server, where layout effects never run and would otherwise warn.
-const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+import { useCallback, useRef } from "react";
 
 /**
- * Persist a nested scroll container's position across route navigations, keyed
- * in sessionStorage. Next.js restores window scroll on back-navigation but not
+ * Persist a nested scroll container's position across navigation, keyed in
+ * sessionStorage. Next.js restores window scroll on back-navigation but not
  * nested overflow containers, so a list inside one snaps back to the top.
  *
- * Attach the returned ref to the scroll container: the position is saved as you
- * scroll and restored on mount. Lists that load their content asynchronously
- * mount too short to reach the saved offset, so the position is re-applied as
- * the content grows until the target is reachable, the user scrolls, or a
- * timeout passes. Remove sessionStorage[key] elsewhere to force a fresh top on a
- * deliberate entry (the sidebar does this for "settings-scroll").
+ * Returns a callback ref — attach it to the scroll container (`ref={scrollRef}`).
+ * Keying off the element mounting (rather than the component) means it also
+ * works when a page swaps the list out for a detail view on the *same* route
+ * (query-param views, e.g. plugins/mcp-servers): the scroller element unmounts
+ * and remounts, and we re-attach each time.
+ *
+ * On attach it restores the saved position (re-pinning as asynchronously-loaded
+ * content grows so a list that mounts empty still lands in place; a real user
+ * scroll or a timeout aborts), and saves as you scroll. Remove sessionStorage[key]
+ * elsewhere to force a fresh top on a deliberate entry (the sidebar does this for
+ * "settings-scroll").
  */
 export function useScrollRestoration<T extends HTMLElement>(key: string) {
-  const ref = useRef<T | null>(null);
+  const detach = useRef<(() => void) | null>(null);
 
-  useIsomorphicLayoutEffect(() => {
-    const el = ref.current;
-    if (!el) return;
+  return useCallback(
+    (el: T | null) => {
+      // Detach from any previously-attached element (remount / unmount).
+      detach.current?.();
+      detach.current = null;
+      if (!el) return;
 
-    const raw = sessionStorage.getItem(key);
-    const target = raw !== null ? Number(raw) : Number.NaN;
-    let restoring = Number.isFinite(target) && target > 0;
-    let pollId = 0;
-    let saveFrame = 0;
+      const raw = sessionStorage.getItem(key);
+      const target = raw !== null ? Number(raw) : Number.NaN;
+      let restoring = Number.isFinite(target) && target > 0;
+      let pollId = 0;
+      let saveFrame = 0;
 
-    const stopRestore = () => {
-      restoring = false;
-      if (pollId) cancelAnimationFrame(pollId);
-      pollId = 0;
-      el.removeEventListener("wheel", stopRestore);
-      el.removeEventListener("touchstart", stopRestore);
-      el.removeEventListener("keydown", stopRestore);
-    };
-
-    if (restoring) {
-      // Apply synchronously first (no flash when the content is already tall).
-      el.scrollTop = target;
-      if (Math.abs(el.scrollTop - target) < 2) {
+      const stopRestore = () => {
         restoring = false;
-      } else {
-        // Content is still loading and too short to reach the offset — re-pin it
-        // each frame as the list grows. A real user scroll (wheel/touch/key —
-        // none of which fire from a programmatic scrollTop) aborts immediately.
-        let frames = 0;
-        const poll = () => {
-          if (!restoring) return;
-          el.scrollTop = target;
-          frames++;
-          if (Math.abs(el.scrollTop - target) < 2 || frames > 120) {
-            stopRestore();
-            return;
-          }
+        if (pollId) cancelAnimationFrame(pollId);
+        pollId = 0;
+        el.removeEventListener("wheel", stopRestore);
+        el.removeEventListener("touchstart", stopRestore);
+        el.removeEventListener("keydown", stopRestore);
+      };
+
+      if (restoring) {
+        // Apply synchronously on attach (before paint, no flash when the content
+        // is already tall enough).
+        el.scrollTop = target;
+        if (Math.abs(el.scrollTop - target) < 2) {
+          restoring = false;
+        } else {
+          // Content is still loading and too short — re-pin each frame as the
+          // list grows. A real user scroll (wheel/touch/key, none of which fire
+          // from a programmatic scrollTop) aborts immediately.
+          let frames = 0;
+          const poll = () => {
+            if (!restoring) return;
+            el.scrollTop = target;
+            frames++;
+            if (Math.abs(el.scrollTop - target) < 2 || frames > 120) {
+              stopRestore();
+              return;
+            }
+            pollId = requestAnimationFrame(poll);
+          };
+          el.addEventListener("wheel", stopRestore, { passive: true });
+          el.addEventListener("touchstart", stopRestore, { passive: true });
+          el.addEventListener("keydown", stopRestore);
           pollId = requestAnimationFrame(poll);
-        };
-        el.addEventListener("wheel", stopRestore, { passive: true });
-        el.addEventListener("touchstart", stopRestore, { passive: true });
-        el.addEventListener("keydown", stopRestore);
-        pollId = requestAnimationFrame(poll);
+        }
       }
-    }
 
-    const onScroll = () => {
-      // Ignore the scroll events our own restore generates; only persist genuine
-      // post-restore positions.
-      if (restoring || saveFrame) return;
-      saveFrame = requestAnimationFrame(() => {
-        saveFrame = 0;
-        sessionStorage.setItem(key, String(el.scrollTop));
-      });
-    };
-    el.addEventListener("scroll", onScroll, { passive: true });
+      const onScroll = () => {
+        // Ignore the scroll events our own restore generates.
+        if (restoring || saveFrame) return;
+        saveFrame = requestAnimationFrame(() => {
+          saveFrame = 0;
+          sessionStorage.setItem(key, String(el.scrollTop));
+        });
+      };
+      el.addEventListener("scroll", onScroll, { passive: true });
 
-    return () => {
-      const wasRestoring = restoring;
-      stopRestore();
-      if (saveFrame) cancelAnimationFrame(saveFrame);
-      el.removeEventListener("scroll", onScroll);
-      // Flush the latest position, but don't clobber the saved target with a
-      // clamped value if we unmounted before the content finished loading.
-      if (!wasRestoring) sessionStorage.setItem(key, String(el.scrollTop));
-    };
-  }, [key]);
-
-  return ref;
+      detach.current = () => {
+        const wasRestoring = restoring;
+        stopRestore();
+        if (saveFrame) cancelAnimationFrame(saveFrame);
+        el.removeEventListener("scroll", onScroll);
+        // Flush the latest position, but don't clobber the saved target with a
+        // clamped value if we detached before the content finished loading.
+        if (!wasRestoring) sessionStorage.setItem(key, String(el.scrollTop));
+      };
+    },
+    [key],
+  );
 }

--- a/src/hooks/use-scroll-restoration.ts
+++ b/src/hooks/use-scroll-restoration.ts
@@ -1,0 +1,91 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+
+// useLayoutEffect on the client (restore before paint, no flash); useEffect on
+// the server, where layout effects never run and would otherwise warn.
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+/**
+ * Persist a nested scroll container's position across route navigations, keyed
+ * in sessionStorage. Next.js restores window scroll on back-navigation but not
+ * nested overflow containers, so a list inside one snaps back to the top.
+ *
+ * Attach the returned ref to the scroll container: the position is saved as you
+ * scroll and restored on mount. Lists that load their content asynchronously
+ * mount too short to reach the saved offset, so the position is re-applied as
+ * the content grows until the target is reachable, the user scrolls, or a
+ * timeout passes. Remove sessionStorage[key] elsewhere to force a fresh top on a
+ * deliberate entry (the sidebar does this for "settings-scroll").
+ */
+export function useScrollRestoration<T extends HTMLElement>(key: string) {
+  const ref = useRef<T | null>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const raw = sessionStorage.getItem(key);
+    const target = raw !== null ? Number(raw) : Number.NaN;
+    let restoring = Number.isFinite(target) && target > 0;
+    let pollId = 0;
+    let saveFrame = 0;
+
+    const stopRestore = () => {
+      restoring = false;
+      if (pollId) cancelAnimationFrame(pollId);
+      pollId = 0;
+      el.removeEventListener("wheel", stopRestore);
+      el.removeEventListener("touchstart", stopRestore);
+      el.removeEventListener("keydown", stopRestore);
+    };
+
+    if (restoring) {
+      // Apply synchronously first (no flash when the content is already tall).
+      el.scrollTop = target;
+      if (Math.abs(el.scrollTop - target) < 2) {
+        restoring = false;
+      } else {
+        // Content is still loading and too short to reach the offset — re-pin it
+        // each frame as the list grows. A real user scroll (wheel/touch/key —
+        // none of which fire from a programmatic scrollTop) aborts immediately.
+        let frames = 0;
+        const poll = () => {
+          if (!restoring) return;
+          el.scrollTop = target;
+          frames++;
+          if (Math.abs(el.scrollTop - target) < 2 || frames > 120) {
+            stopRestore();
+            return;
+          }
+          pollId = requestAnimationFrame(poll);
+        };
+        el.addEventListener("wheel", stopRestore, { passive: true });
+        el.addEventListener("touchstart", stopRestore, { passive: true });
+        el.addEventListener("keydown", stopRestore);
+        pollId = requestAnimationFrame(poll);
+      }
+    }
+
+    const onScroll = () => {
+      // Ignore the scroll events our own restore generates; only persist genuine
+      // post-restore positions.
+      if (restoring || saveFrame) return;
+      saveFrame = requestAnimationFrame(() => {
+        saveFrame = 0;
+        sessionStorage.setItem(key, String(el.scrollTop));
+      });
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+
+    return () => {
+      const wasRestoring = restoring;
+      stopRestore();
+      if (saveFrame) cancelAnimationFrame(saveFrame);
+      el.removeEventListener("scroll", onScroll);
+      // Flush the latest position, but don't clobber the saved target with a
+      // clamped value if we unmounted before the content finished loading.
+      if (!wasRestoring) sessionStorage.setItem(key, String(el.scrollTop));
+    };
+  }, [key]);
+
+  return ref;
+}

--- a/src/hooks/use-session.ts
+++ b/src/hooks/use-session.ts
@@ -1179,9 +1179,14 @@ export function useSession(sessionId: string, cwd?: string, historyView?: boolea
         text: apiText,
         images: images?.length ? images : undefined,
         documents: documents?.length ? documents : undefined,
+        cwd: cwd || undefined,
+        // When sending from a history view, the server must resume the exact
+        // transcript link being viewed (not the chain head) so the view and the
+        // agent stay in sync.
+        historyView: historyView || undefined,
       });
     },
-    [send, sessionId, queuePaused, cwd],
+    [send, sessionId, queuePaused, cwd, historyView],
   );
 
   const interrupt = useCallback(() => {

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -5,7 +5,7 @@ import { splitLegacyModel } from "@/lib/models";
 import type { ModelSlots } from "@/types";
 
 export type DiffStyle = "split" | "unified";
-export type ThinkingLevel = "low" | "medium" | "high" | "xhigh" | "max";
+export type ThinkingLevel = "off" | "low" | "medium" | "high" | "xhigh" | "max";
 export type TerminalTheme =
   | "cockpit"
   | "dark"

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -13,7 +13,7 @@ export function contextSizeToWindow(size: ContextSize): number {
   return CONTEXT_SIZES[size].window;
 }
 
-export type ModelAlias = "opus" | "sonnet" | "haiku";
+export type ModelAlias = "opus" | "sonnet" | "haiku" | "fable";
 
 export interface ModelEntry {
   alias: ModelAlias;
@@ -78,6 +78,17 @@ export const MODELS: ModelEntry[] = [
     isDefault: true,
     supportsXhigh: true,
   },
+  {
+    alias: "fable",
+    version: "5",
+    modelId: "claude-fable-5",
+    displayName: "Fable 5",
+    description: "Most powerful",
+    contextSizes: ["200k", "1m"],
+    contextWindow: 200_000,
+    isDefault: true,
+    supportsXhigh: true,
+  },
 ];
 
 export function findModelById(modelId: string | undefined | null): ModelEntry | undefined {
@@ -96,7 +107,7 @@ export function defaultForAlias(alias: ModelAlias): ModelEntry | undefined {
 export function resolveModel(model: string | undefined | null): ModelEntry | null {
   if (!model) return null;
   const base = model.replace(/\[.*\]$/, "");
-  if (base === "opus" || base === "sonnet" || base === "haiku") {
+  if (base === "opus" || base === "sonnet" || base === "haiku" || base === "fable") {
     return defaultForAlias(base) ?? null;
   }
   return findModelById(base) ?? null;
@@ -120,6 +131,8 @@ export function recommendedEffort(entry: ModelEntry | null | undefined): Thinkin
 export function coerceEffort(level: ThinkingLevel, entry: ModelEntry | null | undefined): ThinkingLevel | null {
   const allowed = allowedEffortLevels(entry);
   if (allowed.length === 0) return null;
+  // "off" (thinking disabled) is valid for any thinking-capable model — preserve it.
+  if (level === "off") return "off";
   if (allowed.includes(level)) return level;
   return recommendedEffort(entry) ?? allowed[allowed.length - 1] ?? null;
 }
@@ -152,4 +165,43 @@ export function resolveProviderId(currentModel: string, providers: { id: string;
   const stripped = currentModel.replace(/\[.*\]$/, "");
   const provider = providers.find((p) => p.models.some((m) => m.modelId === stripped || `${p.id}:${m.modelId}` === stripped));
   return provider?.id ?? "anthropic";
+}
+
+/**
+ * Resolve a stored model string to a short display label, the effective
+ * thinking level, and the context size to show. thinking=null when the model
+ * does not allow the given level (e.g. haiku, or a custom model without that
+ * effort); context=null when the model offers only one size (nothing to
+ * disambiguate), mirroring the session-settings UI. Powers the input-area pill.
+ */
+export function describeModelSelection(
+  currentModel: string,
+  thinkingLevel: ThinkingLevel,
+  contextSize: ContextSize,
+  providers: { id: string; models: ProviderModel[] }[] | undefined,
+): { label: string; thinking: ThinkingLevel | null; context: ContextSize | null } {
+  const entry = resolveModel(currentModel);
+  if (entry) {
+    const allowed = allowedEffortLevels(entry);
+    return {
+      label: entry.displayName,
+      // "off" shows whenever the model can think (it disables thinking); effort
+      // levels show when allowed. Haiku (no thinking) shows nothing.
+      thinking: allowed.length > 0 && (thinkingLevel === "off" || allowed.includes(thinkingLevel)) ? thinkingLevel : null,
+      context: entry.contextSizes.length >= 2 ? contextSize : null,
+    };
+  }
+  const base = currentModel.replace(/\[.*\]$/, "");
+  for (const p of providers ?? []) {
+    const m = p.models.find((pm) => pm.modelId === base || `${p.id}:${pm.modelId}` === base);
+    if (m) {
+      const lv = m.effortLevels ?? [];
+      return {
+        label: m.displayName || m.modelId,
+        thinking: lv.length > 0 && (thinkingLevel === "off" || lv.includes(thinkingLevel)) ? thinkingLevel : null,
+        context: (m.contextSizes ?? []).length >= 2 ? contextSize : null,
+      };
+    }
+  }
+  return { label: base.replace(/^[^:]+:/, "") || base, thinking: null, context: null };
 }

--- a/src/server/claude-bin.ts
+++ b/src/server/claude-bin.ts
@@ -1,13 +1,25 @@
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { isAbsolute } from "node:path";
 
 let resolvedClaudeBin: string | null = null;
 
 /**
- * Resolve the `claude` executable path once and cache it for the process.
- * Falls back to the bare "claude" name (relying on PATH) if resolution fails.
+ * Resolve the `claude` executable path and cache it for the process.
+ *
+ * The cache is invalidated when the resolved absolute path no longer exists, so
+ * a `claude` self-update that deletes the old versioned binary out from under a
+ * long-running server is picked up on the next spawn instead of wedging every
+ * session with `execvp: No such file or directory` until a manual restart.
+ * `existsSync` follows symlinks, so a stable launcher symlink the updater
+ * repoints stays valid; only a cached path to a now-deleted binary re-resolves.
+ * The bare-name PATH fallback is left cached as-is — it has no fixed path to
+ * validate and exec-time PATH resolution handles it.
  */
 export function getClaudeBin(): string {
-  if (resolvedClaudeBin) return resolvedClaudeBin;
+  if (resolvedClaudeBin && (!isAbsolute(resolvedClaudeBin) || existsSync(resolvedClaudeBin))) {
+    return resolvedClaudeBin;
+  }
   const cmd = process.platform === "win32" ? "where" : "which";
   try {
     resolvedClaudeBin = execFileSync(cmd, ["claude"], { encoding: "utf-8" }).trim().split("\n")[0];

--- a/src/server/claude-settings.ts
+++ b/src/server/claude-settings.ts
@@ -29,6 +29,11 @@ export interface HookSettingsOptions {
   /** Tools to pre-authorize so PermissionRequest never fires for them. */
   allowList?: string[];
   denyList?: string[];
+  /**
+   * Per-session thinking state. false writes alwaysThinkingEnabled:false (the
+   * CLI's "thinking off"); true forces it on; undefined leaves the user default.
+   */
+  thinkingEnabled?: boolean;
 }
 
 export interface HookSettingsArtifact {
@@ -76,6 +81,9 @@ export async function prepareHookSettings(opts: HookSettingsOptions): Promise<Ho
     // interactive "WARNING: Bypass Permissions mode" dialog has nowhere to go
     // when there's no human at the TUI, so suppress it here.
     skipDangerousModePermissionPrompt: true,
+    // Per-session thinking on/off. cockpit's selector is authoritative, so this
+    // overrides any user-global alwaysThinkingEnabled when explicitly provided.
+    ...(opts.thinkingEnabled !== undefined ? { alwaysThinkingEnabled: opts.thinkingEnabled } : {}),
   };
 
   const dir = await resolveSettingsDir();

--- a/src/server/mcp/cockpit-config-server.ts
+++ b/src/server/mcp/cockpit-config-server.ts
@@ -115,7 +115,7 @@ const TOOL_DEFINITIONS = [
     inputSchema: {
       type: "object",
       properties: {
-        thinkingLevel: { type: "string", enum: ["low", "medium", "high", "xhigh", "max"] },
+        thinkingLevel: { type: "string", enum: ["off", "low", "medium", "high", "xhigh", "max"] },
         diffStyle: { type: "string", enum: ["split", "unified"] },
         dismissKeyboardOnSend: { type: "boolean" },
         thinkingExpanded: { type: "boolean" },

--- a/src/server/pty-runtime.ts
+++ b/src/server/pty-runtime.ts
@@ -26,6 +26,8 @@ export interface PtyRuntimeOptions {
   /** Tools to pre-authorize at settings level so PermissionRequest never fires. */
   allowList?: string[];
   denyList?: string[];
+  /** When false, the CLI spawns with thinking disabled (alwaysThinkingEnabled:false in the settings file). */
+  thinkingEnabled?: boolean;
   /** Optional debug callback for raw PTY data chunks. */
   onPtyData?: (chunk: string) => void;
 }
@@ -79,6 +81,7 @@ export class PtyRuntime {
       hookToken: token,
       allowList: this.opts.allowList,
       denyList: this.opts.denyList,
+      thinkingEnabled: this.opts.thinkingEnabled,
     });
     this.settingsPath = settingsPath;
     logDiag(sessionId, "pty:hooks-ready", { elapsedMs: Date.now() - startAt });

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -1201,6 +1201,7 @@ export class SessionManager {
       : (() => {
           const levels = this.modelEffortLevels(model);
           if (levels.length === 0) return null;
+          if (session.thinkingLevel === "off") return "off";
           if (levels.includes(session.thinkingLevel)) return session.thinkingLevel;
           return levels[levels.length - 1];
         })();
@@ -1223,7 +1224,7 @@ export class SessionManager {
         const effortRequest = {
           type: "control_request",
           request_id: `effort-${Date.now()}`,
-          request: { subtype: "apply_flag_settings", settings: { effort: session.thinkingLevel } },
+          request: { subtype: "apply_flag_settings", settings: this.thinkingFlagSettings(session.thinkingLevel) },
         };
         session.stdin.write(JSON.stringify(effortRequest) + "\n");
       }
@@ -1270,6 +1271,15 @@ export class SessionManager {
     return this.sessions.get(sessionId)?.info.model || "sonnet";
   }
 
+  /**
+   * Settings patch for the CLI's apply_flag_settings / settings file. "off"
+   * disables thinking via alwaysThinkingEnabled (there is no --effort value for
+   * it); any other level sets effort and ensures thinking is enabled.
+   */
+  private thinkingFlagSettings(level: ThinkingLevel): Record<string, unknown> {
+    return level === "off" ? { alwaysThinkingEnabled: false } : { effort: level, alwaysThinkingEnabled: true };
+  }
+
   setThinkingLevel(sessionId: string, level: ThinkingLevel): void {
     const session = this.sessions.get(sessionId);
     if (!session || session.thinkingLevel === level) return;
@@ -1281,7 +1291,7 @@ export class SessionManager {
       const request = {
         type: "control_request",
         request_id: `effort-${Date.now()}`,
-        request: { subtype: "apply_flag_settings", settings: { effort: level } },
+        request: { subtype: "apply_flag_settings", settings: this.thinkingFlagSettings(level) },
       };
       session.stdin.write(JSON.stringify(request) + "\n");
     } else if (!session.stdin) {
@@ -2265,7 +2275,9 @@ Additional Cockpit rules beyond the CLI's defaults:
       args.push("--model", cliModel);
     }
 
-    if (this.modelEffortLevels(session.info.model).length > 0) {
+    // "off" has no --effort value; thinking is disabled via a post-init
+    // apply_flag_settings control request below instead.
+    if (this.modelEffortLevels(session.info.model).length > 0 && session.thinkingLevel !== "off") {
       args.push("--effort", session.thinkingLevel);
     }
 
@@ -2349,6 +2361,17 @@ Additional Cockpit rules beyond the CLI's defaults:
       this.sendPermissionMode(session, sessionId, "plan");
     } else if (session.bypassAllPermissions && !session.cockpitAgent) {
       this.sendPermissionMode(session, sessionId, "bypassPermissions");
+    }
+
+    // Thinking "off": there is no --effort value for it and stream mode has no
+    // --settings file, so disable thinking as a settings patch over stdin.
+    if (session.thinkingLevel === "off" && this.modelEffortLevels(session.info.model).length > 0) {
+      const offRequest = {
+        type: "control_request",
+        request_id: `thinking-off-${Date.now()}`,
+        request: { subtype: "apply_flag_settings", settings: { alwaysThinkingEnabled: false } },
+      };
+      proc.stdin!.write(JSON.stringify(offRequest) + "\n");
     }
 
     if (text) {
@@ -2526,7 +2549,9 @@ Additional Cockpit rules beyond the CLI's defaults:
     const resolvedPty = resolveProviderModel(session.info.model ?? "sonnet");
     const cliModelPty = resolvedPty ? resolvedPty.model.modelId : session.info.model;
     if (cliModelPty) extraArgs.push("--model", cliModelPty);
-    if (this.modelEffortLevels(session.info.model).length > 0) {
+    // "off" is applied via the settings file (alwaysThinkingEnabled:false) passed
+    // to PtyRuntime below, not --effort (which has no "off" value).
+    if (this.modelEffortLevels(session.info.model).length > 0 && session.thinkingLevel !== "off") {
       extraArgs.push("--effort", session.thinkingLevel);
     }
     if (session.planMode) {
@@ -2578,6 +2603,7 @@ Additional Cockpit rules beyond the CLI's defaults:
       claudeBin: getClaudeBin(),
       extraArgs,
       extraEnv,
+      thinkingEnabled: session.thinkingLevel !== "off",
       onEvents: (events) => {
         const types = events.map((e) => e.type).join(", ");
         console.log(`[sm] pty onEvents for ${sessionId.slice(0, 8)}: [${types}]`);

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -280,12 +280,17 @@ export class SessionManager {
     }
   }
 
-  ensureSession(id: string, cwd: string): Session {
+  ensureSession(id: string, cwd: string, opts?: { pinCliSessionId?: string }): Session {
     let session = this.sessions.get(id);
     if (!session) {
       const prefs = getSessionPrefs(id);
-      const cliId = prefs?.cliSessionId || id;
-      const prevIds = prefs?.previousCliSessionIds || [];
+      // pinCliSessionId forces the session to resume an exact transcript link
+      // (history-view continue), with that link's ancestors as the stitch chain,
+      // overriding the usual "resolve to the chain head" behaviour.
+      const cliId = opts?.pinCliSessionId || prefs?.cliSessionId || id;
+      const prevIds = opts?.pinCliSessionId
+        ? (findChainForCliSession(opts.pinCliSessionId)?.truncatedPrevIds ?? [])
+        : prefs?.previousCliSessionIds || [];
       const short = id.slice(0, 8);
       debugLog(
         `[session:${short}] ensureSession: cliSessionId=${cliId.slice(0, 8)}, prevIds=[${prevIds.map((p) => p.slice(0, 8)).join(",")}], hasPrefs=${!!prefs}`,
@@ -2076,16 +2081,25 @@ Additional Cockpit rules beyond the CLI's defaults:
 </system-reminder>`;
   }
 
-  async recoverSession(id: string): Promise<boolean> {
+  async recoverSession(id: string, opts?: { cwd?: string; pinExact?: boolean }): Promise<boolean> {
     if (this.sessions.has(id)) return true;
     smLog(id, "recovering session: not in memory, searching disk");
     const prefs = getSessionPrefs(id);
-    const cwd = (await findSessionCwd(prefs?.cliSessionId || id)) || (await findSessionCwd(id));
+    const cwd = (await findSessionCwd(prefs?.cliSessionId || id)) || (await findSessionCwd(id)) || opts?.cwd;
     if (!cwd) {
       smLog(id, "recovery failed: no transcript found on disk");
       return false;
     }
-    this.ensureSession(id, cwd);
+    // When recovered from a history-view deep link, `id` is the exact transcript
+    // link being viewed, which may be an older link of a compacted/cleared chain.
+    // Pin it as the cliSessionId so the resume continues that link (--resume
+    // appends to the same file) instead of jumping to the chain head — otherwise
+    // the view and the agent diverge.
+    if (opts?.pinExact && transcriptExists(id, cwd)) {
+      this.ensureSession(id, cwd, { pinCliSessionId: id });
+    } else {
+      this.ensureSession(id, cwd);
+    }
     smLog(id, `recovery succeeded: restored from ${cwd}`);
     return true;
   }

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -389,15 +389,16 @@ export class SessionManager {
       // pointer to a regular session (e.g. a hand-edited assistant.json) must not
       // be rehydrated here — it would lack the MCP-disable/permission restrictions.
       if (prefs?.cockpitAgent) {
-        const cwd = (await findSessionCwd(prefs.cliSessionId || stored)) ?? (await findSessionCwd(stored));
-        if (cwd) {
-          // ensureSession rebuilds in-memory state and (Step 5) registers the MCP-disable
-          // onInit listener. Model/thinking are restored from session-prefs — which the
-          // in-modal selector and the settings-page write-through both keep current —
-          // so no re-apply is needed here.
-          this.ensureSession(stored, cwd);
-          return stored;
-        }
+        // The assistant's cwd is always getCockpitDir(); fall back to it when no
+        // transcript exists yet (the assistant was changed but never messaged) so
+        // its model/thinking still restore from session-prefs instead of the
+        // session being recreated from the assistant.json fallback (Sonnet/High).
+        const cwd = (await findSessionCwd(prefs.cliSessionId || stored)) ?? (await findSessionCwd(stored)) ?? getCockpitDir();
+        // ensureSession rebuilds in-memory state and (Step 5) registers the MCP-disable
+        // onInit listener. Model/thinking are restored from session-prefs — which the
+        // in-modal selector keeps current — so no re-apply is needed here.
+        this.ensureSession(stored, cwd);
+        return stored;
       }
     }
     // No stored id, or its transcript is gone — create a fresh session seeded from
@@ -1881,13 +1882,12 @@ export class SessionManager {
           return true;
         }
         this.log(sessionId, `/model command: args="${args}", was=${session.info.model}`);
-        this.killProcess(session);
-        session.info.model = args;
-        session.info.status = "idle";
-        session.emitter.emit("status", sessionId, "idle");
-        setSessionPrefs(sessionId, { model: args });
+        // Route through setModel so model + modelSlots.main + contextSize persist
+        // together (and the process restarts correctly per runtime). Writing only
+        // prefs.model left modelSlots.main stale, and rehydrate prefers modelSlots,
+        // so the switch reverted on restart.
+        this.setModel(sessionId, args);
         this.emitSystem(session, sessionId, `Model switched to ${args}`);
-        this.emitInfoUpdated(session, sessionId);
         return true;
       }
 

--- a/src/server/transcript.ts
+++ b/src/server/transcript.ts
@@ -283,6 +283,27 @@ function stripAnsi(s: string): string {
   return s.replace(ANSI_RE, "");
 }
 
+// Adaptive-thinking models (Fable especially) can emit several thinking blocks
+// in one turn. The CLI writes each as its own JSONL entry under a single
+// message.id with a distinct signature, so the merge below would otherwise stack
+// them; rendered as omitted-display empty strips they read as duplicates. Collapse
+// adjacent thinking blocks into one, matching the live stream path
+// (use-session.ts assistant:thinking). No-op for models that emit a single
+// thinking block per turn (e.g. Opus), and non-adjacent thinking (interleaved
+// around tool calls) is preserved.
+function pushBlockCoalescingThinking(target: ContentBlock[], block: ContentBlock): void {
+  if (block.type === "thinking") {
+    const last = target[target.length - 1];
+    if (last && last.type === "thinking") {
+      last.text = last.text && block.text ? `${last.text}\n\n${block.text}` : last.text + block.text;
+      if (block.redacted) last.redacted = true;
+      if (block.durationMs) last.durationMs = block.durationMs;
+      return;
+    }
+  }
+  target.push(block);
+}
+
 function parseLines(lines: string[]): { messages: ChatMessage[]; lastUsage: { used: number; total: number } | null } {
   const messages: ChatMessage[] = [];
   const messageById = new Map<string, ChatMessage>();
@@ -494,7 +515,7 @@ function parseLines(lines: string[]): { messages: ChatMessage[]; lastUsage: { us
         if (block.type === "thinking") {
           const redacted = !block.thinking && !!block.signature;
           if (!block.thinking && !redacted) continue;
-          blocks.push({ type: "thinking", text: block.thinking ?? "", durationMs: thinkingDurationMs, redacted });
+          pushBlockCoalescingThinking(blocks, { type: "thinking", text: block.thinking ?? "", durationMs: thinkingDurationMs, redacted });
         } else if (block.type === "text" && block.text) {
           const cleaned = stripCliXml(block.text);
           if (cleaned) {
@@ -529,10 +550,10 @@ function parseLines(lines: string[]): { messages: ChatMessage[]; lastUsage: { us
           }
         }
         for (const b of blocks) {
-          if (b.type === "tool_use") {
-            if (existing.blocks.some((eb) => eb.type === "tool_use" && eb.toolUse.id === b.toolUse.id)) continue;
+          if (b.type === "tool_use" && existing.blocks.some((eb) => eb.type === "tool_use" && eb.toolUse.id === b.toolUse.id)) {
+            continue;
           }
-          existing.blocks.push(b);
+          pushBlockCoalescingThinking(existing.blocks, b);
         }
       } else {
         const msg: ChatMessage = {

--- a/src/server/ws-handler.ts
+++ b/src/server/ws-handler.ts
@@ -596,7 +596,7 @@ export function createWebSocketHandler(
           }
           const sent = sessionManager.sendMessage(msg.sessionId, msg.text, msg.images, msg.documents);
           if (!sent) {
-            sessionManager.recoverSession(msg.sessionId).then((recovered) => {
+            sessionManager.recoverSession(msg.sessionId, { cwd: msg.cwd, pinExact: msg.historyView }).then((recovered) => {
               if (recovered) {
                 subscribeSession(msg.sessionId);
                 sessionManager.sendMessage(msg.sessionId, msg.text, msg.images, msg.documents);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -296,7 +296,15 @@ export interface NotificationSettings {
 // Client -> Server messages
 export type ClientMessage =
   | { type: "session:connect"; sessionId: string; cwd?: string; lastMessageId?: string | null; historyView?: boolean }
-  | { type: "message:send"; sessionId: string; text: string; images?: ImageAttachment[]; documents?: DocumentAttachment[] }
+  | {
+      type: "message:send";
+      sessionId: string;
+      text: string;
+      images?: ImageAttachment[];
+      documents?: DocumentAttachment[];
+      cwd?: string;
+      historyView?: boolean;
+    }
   | { type: "session:interrupt"; sessionId: string }
   | {
       type: "permission:response";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -151,7 +151,7 @@ export interface PermissionSuggestion {
   destination?: string;
 }
 
-export type ThinkingLevel = "low" | "medium" | "high" | "xhigh" | "max";
+export type ThinkingLevel = "off" | "low" | "medium" | "high" | "xhigh" | "max";
 
 export interface UsageLimit {
   /** Percentage 0-100 */

--- a/tests/claude-bin.test.ts
+++ b/tests/claude-bin.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted so the vi.mock factories below can reference them and they survive
+// vi.resetModules() (which we use to reset claude-bin's module-level cache).
+const { mockExecFileSync, mockExistsSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  mockExistsSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({ execFileSync: mockExecFileSync }));
+vi.mock("node:fs", () => ({ existsSync: mockExistsSync }));
+
+async function loadGetClaudeBin() {
+  vi.resetModules();
+  return (await import("@/server/claude-bin")).getClaudeBin;
+}
+
+describe("getClaudeBin", () => {
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+    mockExistsSync.mockReset();
+  });
+
+  it("resolves via which once and serves the cached path while it still exists", async () => {
+    mockExecFileSync.mockReturnValue("/usr/local/bin/claude\n");
+    mockExistsSync.mockReturnValue(true);
+    const getClaudeBin = await loadGetClaudeBin();
+
+    expect(getClaudeBin()).toBe("/usr/local/bin/claude");
+    expect(getClaudeBin()).toBe("/usr/local/bin/claude");
+    // Resolved exactly once; the second call is served from the validated cache.
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-resolves when the cached absolute binary was deleted (claude self-update)", async () => {
+    mockExecFileSync
+      .mockReturnValueOnce("/home/u/.local/share/claude/versions/2.1.170\n")
+      .mockReturnValueOnce("/home/u/.local/bin/claude\n");
+    // The first cached path is gone by the time it is re-validated on the 2nd call.
+    mockExistsSync.mockReturnValueOnce(false);
+    const getClaudeBin = await loadGetClaudeBin();
+
+    expect(getClaudeBin()).toBe("/home/u/.local/share/claude/versions/2.1.170");
+    // Cached binary vanished under the long-running server -> re-resolve, don't wedge.
+    expect(getClaudeBin()).toBe("/home/u/.local/bin/claude");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches the bare-name PATH fallback and does not re-run which or stat it", async () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("which: claude: not found");
+    });
+    const getClaudeBin = await loadGetClaudeBin();
+
+    expect(getClaudeBin()).toBe("claude");
+    expect(getClaudeBin()).toBe("claude");
+    // "claude" is relative: not existsSync-validated, stays cached after one resolve.
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+});

--- a/tests/claude-settings.test.ts
+++ b/tests/claude-settings.test.ts
@@ -52,6 +52,21 @@ describe("prepareHookSettings", () => {
     });
   });
 
+  it("writes alwaysThinkingEnabled from thinkingEnabled (false disables, true forces on)", async () => {
+    const read = async (id: string, thinkingEnabled: boolean): Promise<Record<string, unknown>> => {
+      cleanupIds.push(id);
+      const { settingsPath } = await prepareHookSettings({
+        sessionId: id,
+        hookUrl: "http://127.0.0.1:1",
+        hookToken: "tok",
+        thinkingEnabled,
+      });
+      return JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+    };
+    expect((await read("test-think-off", false)).alwaysThinkingEnabled).toBe(false);
+    expect((await read("test-think-on", true)).alwaysThinkingEnabled).toBe(true);
+  });
+
   it("respects allow/deny lists", async () => {
     const sessionId = "test-session-2";
     cleanupIds.push(sessionId);

--- a/tests/integration/cockpit-agent-clear.spec.ts
+++ b/tests/integration/cockpit-agent-clear.spec.ts
@@ -1,0 +1,86 @@
+// Integration test: reproduce the reported cockpit-agent bug where using the
+// /clear slash command leaves the agent unable to send ("can't find session",
+// suspected wrong-transcript resume).
+//
+// Creates a cockpit-agent session, sends a message (writes a transcript for the
+// current cliSessionId), /clear (cockpit kills the process and rotates the
+// cliSessionId), then sends again — which must spawn a FRESH CLI session, not
+// fail with a session-not-found / resume error. The /clear rotation and the
+// transcriptExists-based resume decision are shared by both runtimes.
+//
+// Skips cleanly if no CLI on PATH.
+
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { textResponse } from "../mock-api/builder";
+import { expect, test } from "./fixtures";
+
+const CLAUDE_BIN = process.env.CLAUDE_BIN ?? "claude";
+const CLAUDE_AVAILABLE = (() => {
+  try {
+    execSync(`${CLAUDE_BIN} --version`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+test.skip(!CLAUDE_AVAILABLE, `claude binary not found at ${CLAUDE_BIN} (set CLAUDE_BIN env)`);
+
+for (const runtime of ["stream", "pty"] as const) {
+  test(`cockpit agent survives /clear and can send again (${runtime})`, async ({ page, harness }) => {
+    const workDir = mkdtempSync(path.join(tmpdir(), "cockpit-it-clear-"));
+    mkdirSync(path.join(workDir, ".git"), { recursive: true });
+
+    try {
+      harness.mock.setScript([{ events: textResponse("Reply before clear") }, { events: textResponse("Reply after clear") }]);
+
+      const createRes = await page.request.post(`${harness.cockpitUrl}/api/sessions`, {
+        data: { cwd: workDir, runtime, cockpitAgent: true },
+      });
+      expect(createRes.ok()).toBe(true);
+      const { sessionId } = await createRes.json();
+      expect(sessionId).toBeTruthy();
+
+      await page.goto(`${harness.cockpitUrl}/sessions/${sessionId}?cwd=${encodeURIComponent(workDir)}`);
+      const input = page.getByTestId("message-input");
+      await expect(input).toBeVisible();
+      await page.waitForTimeout(5000);
+
+      // 1) First message: writes a transcript for the current cliSessionId.
+      await input.fill("hi");
+      await page.getByTestId("btn-send").click();
+      await expect(page.getByText("Reply before clear")).toBeVisible({ timeout: 30_000 });
+
+      // 2) /clear: cockpit intercepts it, kills the process, rotates cliSessionId.
+      await input.fill("/clear");
+      await page.getByTestId("btn-send").click();
+      await page.waitForTimeout(3000);
+
+      // 3) Send again: must spawn a fresh CLI session, not resume a missing transcript.
+      await input.fill("hello again");
+      await page.getByTestId("btn-send").click();
+
+      const errorLocator = page.getByText(
+        /Session not found|No conversation found|exited during startup|could not be found|Not logged in/i,
+      );
+      await expect
+        .poll(
+          async () => {
+            if (await errorLocator.count()) return "error";
+            if (await page.getByText("Reply after clear").count()) return "reply";
+            return "pending";
+          },
+          { timeout: 30_000, intervals: [500] },
+        )
+        .not.toBe("pending");
+
+      expect(await errorLocator.count(), `session error after /clear: "${(await errorLocator.allInnerTexts()).join(" | ")}"`).toBe(0);
+      await expect(page.getByText("Reply after clear")).toBeVisible();
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+}

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -3,6 +3,7 @@ import {
   allowedEffortLevels,
   coerceEffort,
   defaultForAlias,
+  describeModelSelection,
   findModelById,
   MODELS,
   recommendedEffort,
@@ -10,6 +11,7 @@ import {
   resolveProviderId,
   versionsForAlias,
 } from "@/lib/models";
+import type { ProviderModel } from "@/types";
 
 describe("findModelById", () => {
   it("returns undefined for undefined input", () => {
@@ -319,5 +321,112 @@ describe("resolveProviderId", () => {
 
   it("falls back to anthropic when providers is empty array", () => {
     expect(resolveProviderId("custom:some-model", [])).toBe("anthropic");
+  });
+});
+
+describe("describeModelSelection", () => {
+  const customProviders: { id: string; models: ProviderModel[] }[] = [
+    {
+      id: "lmstudio",
+      models: [{ modelId: "gpt-oss-20b", displayName: "GPT-OSS 20B", effortLevels: ["low", "high"], contextSizes: ["200k", "1m"] }],
+    },
+  ];
+
+  it("labels a built-in opus, keeps an allowed thinking level, and reports the context size", () => {
+    expect(describeModelSelection("opus", "max", "200k", undefined)).toEqual({ label: "Opus 4.8", thinking: "max", context: "200k" });
+  });
+
+  it("reports 1M context when selected on a multi-size model", () => {
+    expect(describeModelSelection("opus", "high", "1m", undefined)).toEqual({ label: "Opus 4.8", thinking: "high", context: "1m" });
+  });
+
+  it("drops thinking for a model with none (haiku) and omits context for a single-size model", () => {
+    expect(describeModelSelection("haiku", "high", "200k", undefined)).toEqual({ label: "Haiku 4.5", thinking: null, context: null });
+  });
+
+  it("drops xhigh for a model that does not allow it (sonnet) but keeps context", () => {
+    expect(describeModelSelection("sonnet", "xhigh", "200k", undefined)).toEqual({ label: "Sonnet 4.6", thinking: null, context: "200k" });
+  });
+
+  it("resolves a built-in by exact modelId", () => {
+    expect(describeModelSelection("claude-opus-4-7", "xhigh", "1m", undefined)).toEqual({
+      label: "Opus 4.7",
+      thinking: "xhigh",
+      context: "1m",
+    });
+  });
+
+  it("strips a [context] suffix before resolving", () => {
+    expect(describeModelSelection("sonnet[1m]", "medium", "200k", undefined)).toEqual({
+      label: "Sonnet 4.6",
+      thinking: "medium",
+      context: "200k",
+    });
+  });
+
+  it("labels a custom provider model by displayName and honours its effortLevels and sizes", () => {
+    expect(describeModelSelection("lmstudio:gpt-oss-20b", "high", "1m", customProviders)).toEqual({
+      label: "GPT-OSS 20B",
+      thinking: "high",
+      context: "1m",
+    });
+    expect(describeModelSelection("lmstudio:gpt-oss-20b", "max", "200k", customProviders)).toEqual({
+      label: "GPT-OSS 20B",
+      thinking: null,
+      context: "200k",
+    });
+  });
+
+  it("matches a custom provider model by bare modelId too", () => {
+    expect(describeModelSelection("gpt-oss-20b", "low", "200k", customProviders)).toEqual({
+      label: "GPT-OSS 20B",
+      thinking: "low",
+      context: "200k",
+    });
+  });
+
+  it("omits context for a single-size custom model", () => {
+    const single: { id: string; models: ProviderModel[] }[] = [
+      { id: "lm", models: [{ modelId: "m", displayName: "M", effortLevels: [], contextSizes: ["200k"] }] },
+    ];
+    expect(describeModelSelection("lm:m", "low", "200k", single)).toEqual({ label: "M", thinking: null, context: null });
+  });
+
+  it("strips a provider prefix and shows no thinking or context for an unknown model", () => {
+    expect(describeModelSelection("ghost:some-model", "high", "1m", [])).toEqual({ label: "some-model", thinking: null, context: null });
+  });
+
+  it("shows off for a custom model that declares effort levels", () => {
+    const providers: { id: string; models: ProviderModel[] }[] = [
+      { id: "lm", models: [{ modelId: "m", displayName: "M", effortLevels: ["low", "high"], contextSizes: ["200k"] }] },
+    ];
+    expect(describeModelSelection("lm:m", "off", "200k", providers).thinking).toBe("off");
+  });
+});
+
+describe("Fable 5", () => {
+  it("resolves by alias and by modelId", () => {
+    expect(resolveModel("fable")?.modelId).toBe("claude-fable-5");
+    expect(resolveModel("claude-fable-5")?.alias).toBe("fable");
+    expect(findModelById("claude-fable-5")?.displayName).toBe("Fable 5");
+    expect(defaultForAlias("fable")?.modelId).toBe("claude-fable-5");
+  });
+
+  it("supports the full effort range including xhigh and max", () => {
+    expect(allowedEffortLevels(resolveModel("fable"))).toEqual(["low", "medium", "high", "xhigh", "max"]);
+  });
+});
+
+describe('thinking "off"', () => {
+  it("coerceEffort keeps off for thinking-capable models and drops it for haiku", () => {
+    expect(coerceEffort("off", resolveModel("opus"))).toBe("off");
+    expect(coerceEffort("off", resolveModel("fable"))).toBe("off");
+    expect(coerceEffort("off", resolveModel("haiku"))).toBeNull();
+  });
+
+  it("describeModelSelection shows off for thinking-capable models, nothing for haiku", () => {
+    expect(describeModelSelection("opus", "off", "200k", undefined).thinking).toBe("off");
+    expect(describeModelSelection("fable", "off", "1m", undefined)).toEqual({ label: "Fable 5", thinking: "off", context: "1m" });
+    expect(describeModelSelection("haiku", "off", "200k", undefined).thinking).toBeNull();
   });
 });

--- a/tests/session-manager-cockpit-agent.test.ts
+++ b/tests/session-manager-cockpit-agent.test.ts
@@ -152,7 +152,7 @@ describe("SessionManager cockpit agent session", () => {
     expect(session.cockpitAgentCleanups.length).toBeGreaterThan(0);
   });
 
-  it("creates a fresh session when the stored id has no transcript", async () => {
+  it("restores the stored cockpit-agent id without recreating when it has no transcript yet (so model/thinking prefs survive)", async () => {
     mockGetSettings.mockReturnValue({ model: "sonnet", thinkingLevel: "high", sessionId: "gone" });
     mockGetPrefs.mockReturnValue({ cockpitAgent: true, cliSessionId: "gone" });
     mockFindCwd.mockResolvedValue(null);
@@ -160,9 +160,12 @@ describe("SessionManager cockpit agent session", () => {
     const createSpy = vi.spyOn(manager, "createSession");
     const id = await manager.getOrCreateCockpitAgentSession();
 
-    expect(id).not.toBe("gone");
-    expect(createSpy).toHaveBeenCalledTimes(1);
-    expect(mockUpdateSettings).toHaveBeenCalledWith({ sessionId: id });
+    // The assistant's cwd is always getCockpitDir(), so a missing transcript must
+    // NOT trigger a fresh recreate from the assistant.json fallback (which would
+    // drop the user's model/thinking). It restores the stored id from prefs.
+    expect(id).toBe("gone");
+    expect(createSpy).not.toHaveBeenCalled();
+    expect((manager as any).sessions.get("gone").cockpitAgent).toBe(true);
   });
 
   it("restores previousCliSessionIds across a /clear round-trip", async () => {

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/server/session-prefs", () => ({
   getSessionPrefs: vi.fn(() => undefined),
   setSessionPrefs: vi.fn(),
   deleteSessionPrefs: vi.fn(),
+  findChainForCliSession: vi.fn(() => null),
 }));
 
 vi.mock("@/server/defaults", () => ({
@@ -185,6 +186,39 @@ describe("SessionManager", () => {
         const s = (manager as any).sessions.get(ensured.info.id)!;
         expect(ensured.info.contextSize).toBe("1m");
         expect(s.contextWindowSize).toBe(1_000_000);
+      } finally {
+        (prefsMod as { getSessionPrefs: (id: string) => unknown }).getSessionPrefs = orig;
+      }
+    });
+
+    it("pinCliSessionId forces resume of the exact viewed link with its ancestors (history-view continue)", async () => {
+      const prefsMod = await import("@/server/session-prefs");
+      const orig = prefsMod.findChainForCliSession;
+      (prefsMod as { findChainForCliSession: (id: string) => unknown }).findChainForCliSession = () => ({
+        cockpitId: "cockpit-C",
+        truncatedPrevIds: ["link-A"],
+      });
+      try {
+        const session = manager.ensureSession("link-T", "/tmp/proj", { pinCliSessionId: "link-T" });
+        expect(session.cliSessionId).toBe("link-T");
+        expect(session.previousCliSessionIds).toEqual(["link-A"]);
+        expect(session.bufferCliSessionId).toBe("link-T");
+      } finally {
+        (prefsMod as { findChainForCliSession: (id: string) => unknown }).findChainForCliSession = orig;
+      }
+    });
+
+    it("without a pin, resolves cliSessionId from prefs (chain head), not the map id", async () => {
+      const prefsMod = await import("@/server/session-prefs");
+      const orig = prefsMod.getSessionPrefs;
+      (prefsMod as { getSessionPrefs: (id: string) => unknown }).getSessionPrefs = () => ({
+        cliSessionId: "head-L",
+        previousCliSessionIds: ["link-A", "link-T"],
+      });
+      try {
+        const session = manager.ensureSession("cockpit-C", "/tmp/proj");
+        expect(session.cliSessionId).toBe("head-L");
+        expect(session.previousCliSessionIds).toEqual(["link-A", "link-T"]);
       } finally {
         (prefsMod as { getSessionPrefs: (id: string) => unknown }).getSessionPrefs = orig;
       }

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -1551,6 +1551,94 @@ describe("transcript module", () => {
     });
   });
 
+  describe("thinking block coalescing", () => {
+    // Fable emits multiple thinking blocks per turn; the CLI writes each as its own
+    // JSONL entry under one message.id with a distinct signature (measured: 49 such
+    // message-ids in a real Fable transcript, 0 in every Opus transcript). Without
+    // coalescing these stack into multiple empty/redacted strips -> visible "duplicate".
+    it("coalesces adjacent thinking blocks emitted across entries, keeping the full span", async () => {
+      (existsSync as any).mockReturnValue(true);
+      const content = jsonl(
+        { type: "user", message: { role: "user", content: "go" }, timestamp: "2024-01-01T00:00:00Z" },
+        {
+          type: "assistant",
+          message: { id: "f1", model: "claude-fable-5", content: [{ type: "thinking", signature: "CAISvUMKYggOGAIq" }] },
+          timestamp: "2024-01-01T00:00:01Z",
+        },
+        {
+          type: "assistant",
+          message: { id: "f1", model: "claude-fable-5", content: [{ type: "thinking", signature: "CAISkwYKYwgOGAIq" }] },
+          timestamp: "2024-01-01T00:00:03Z",
+        },
+        {
+          type: "assistant",
+          message: { id: "f1", model: "claude-fable-5", content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "ls" } }] },
+          timestamp: "2024-01-01T00:00:04Z",
+        },
+      );
+      (readFile as any).mockResolvedValue(content);
+
+      const result = await loadTranscript("session-123", "/tmp");
+
+      const assistant = result.messages.find((m: { role: string }) => m.role === "assistant");
+      expect(assistant).toBeDefined();
+      const thinking = assistant!.blocks.filter((b: { type: string }) => b.type === "thinking");
+      expect(thinking).toHaveLength(1);
+      // duration reflects the later segment (3s from the user turn), not the first (1s)
+      expect(thinking[0]).toMatchObject({ type: "thinking", redacted: true, durationMs: 3000 });
+    });
+
+    it("keeps thinking blocks separated by a tool_use as distinct (interleaved thinking)", async () => {
+      (existsSync as any).mockReturnValue(true);
+      const content = jsonl(
+        {
+          type: "assistant",
+          message: { id: "f2", content: [{ type: "thinking", signature: "sigA" }] },
+          timestamp: "2024-01-01T00:00:00Z",
+        },
+        {
+          type: "assistant",
+          message: { id: "f2", content: [{ type: "tool_use", id: "t1", name: "Bash", input: {} }] },
+          timestamp: "2024-01-01T00:00:01Z",
+        },
+        {
+          type: "assistant",
+          message: { id: "f2", content: [{ type: "thinking", signature: "sigB" }] },
+          timestamp: "2024-01-01T00:00:02Z",
+        },
+      );
+      (readFile as any).mockResolvedValue(content);
+
+      const result = await loadTranscript("session-123", "/tmp");
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].blocks.filter((b: { type: string }) => b.type === "thinking")).toHaveLength(2);
+    });
+
+    it("coalesces multiple thinking blocks within one entry, joining visible text", async () => {
+      (existsSync as any).mockReturnValue(true);
+      const content = jsonl({
+        type: "assistant",
+        message: {
+          id: "f3",
+          content: [
+            { type: "thinking", thinking: "first" },
+            { type: "thinking", thinking: "second" },
+            { type: "text", text: "answer" },
+          ],
+        },
+        timestamp: "2024-01-01T00:00:00Z",
+      });
+      (readFile as any).mockResolvedValue(content);
+
+      const result = await loadTranscript("session-123", "/tmp");
+
+      const thinking = result.messages[0].blocks.filter((b: { type: string }) => b.type === "thinking");
+      expect(thinking).toHaveLength(1);
+      expect((thinking[0] as { text: string }).text).toBe("first\n\nsecond");
+    });
+  });
+
   describe("loadTranscript with tailLines option", () => {
     it("reads tail lines from file using file handle", async () => {
       (existsSync as any).mockReturnValue(true);


### PR DESCRIPTION
Release **0.4.1** — everything accumulated on `next` since `v0.4.0`.

### Added
- **Fable 5, with a model/thinking/context pill.** Fable 5 as a selectable model, an "off" thinking level, and a compact chat-input pill showing the session's current model, thinking level, and context window — tap it to switch any of them inline. The model picker drops the redundant model-id text per row and always shows the version pills.
- **Open-session buttons in search.** Each global-search result and the message-context view get a button that jumps straight into that session.
- **Scroll position persists across navigation.** Every list page (sessions, settings, jobs, reviews, inbox, skills, commands, agents, hooks, MCP servers, plugins) restores its scroll position on back-navigation; search results keep their scroll when the message-context view closes.

### Fixed
- **Cockpit wedged after a Claude CLI self-update.** The cached `claude` binary path is now re-validated and re-resolved when it no longer exists, so a CLI self-update no longer makes every new session fail to spawn (`execvp: No such file or directory`) until a restart.
- **Unsaved custom-provider model dropped on Save.** A typed-but-not-added model (or in-progress inline edit) on the provider Models tab is now folded in on the bottom Save.
- **Session delete after "Load all".** Deleting in an expanded folder now refreshes the list instead of leaving a stale copy until reload; the per-row delete control is always visible on mobile.
- **Model and thinking level reverting across a restart.** The `/model` slash command and the cockpit assistant's selections now persist across a server restart.
- **Continuing a cleared/compacted session from history.** Sending from a history view continues the exact viewed transcript instead of diverging to the chain head.
- **Duplicate thinking strips on Fable turns.** Adjacent thinking blocks are coalesced.
- **Keyboard access for search and session cards.** Invalid nested-button markup replaced with proper controls that activate on Enter/Space and keep open/copy/delete working.

Full notes in `CHANGELOG.md`. After merge: tag `v0.4.1` on `main`.
